### PR TITLE
refactor: remove global border override

### DIFF
--- a/src/components/font-tester.tsx
+++ b/src/components/font-tester.tsx
@@ -62,7 +62,7 @@ export function FontTester() {
   };
 
   return (
-    <div className="fixed top-20 right-4 z-[60] bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg border">
+    <div className="fixed top-20 right-4 z-[60] bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg border border-primary">
       <h3 className="text-sm font-medium mb-3">Font Tester</h3>
       <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
         Current: {appliedFont}
@@ -85,9 +85,9 @@ export function FontTester() {
       >
         Apply Font
       </Button>
-      <Button 
-        variant="outline" 
-        className="mt-1 w-full" 
+      <Button
+        variant="outline"
+        className="mt-1 w-full"
         onClick={resetFont}
       >
         Reset to Default

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-* {
-  border-color: hsl(var(--primary) / 0.7);
-}
 
 body {
   color: hsl(var(--foreground));
@@ -42,34 +39,6 @@ body {
   border: 0.5px solid hsl(var(--primary) / 0.7) !important;
 }
 
-/* Force blue borders only on elements that actually have borders */
-input, 
-textarea,
-.border,
-.rounded-lg,
-.rounded-md,
-.bg-card,
-.card,
-[class*="border-"] {
-  border-color: #3B82F6 !important;
-}
-
-/* Override all possible border color classes */
-.border-gray-200,
-.border-gray-300,
-.border-gray-400,
-.border-gray-500,
-.border-white,
-.border-slate-200,
-.border-slate-300 {
-  border-color: #3B82F6 !important;
-}
-
-input:focus,
-input:focus-visible {
-  border-color: #3B82F6 !important;
-  outline-color: #3B82F6 !important;
-}
 
 /* Ensure proper text contrast */
 .text-muted {


### PR DESCRIPTION
## Summary
- remove global CSS selectors forcing blue borders
- add explicit border-primary utility to font tester component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab83a13b64832dbe9bf906699d6c04