### PR TITLE
refactor: centralize theme button styles

### DIFF
--- a/src/components/theme-selector.tsx
+++ b/src/components/theme-selector.tsx
@@ -1,5 +1,19 @@
 import { useTheme } from "@/contexts/simple-theme-context";
 
+type ThemeOption = {
+  id: "blue" | "pink" | "green" | "orange" | "red";
+  color: string;
+  ringClass: string;
+};
+
+const themeOptions: ThemeOption[] = [
+  { id: "blue", color: "bg-[#007AFF]", ringClass: "ring-blue-300" },
+  { id: "pink", color: "bg-[#FF2D55]", ringClass: "ring-pink-300" },
+  { id: "green", color: "bg-[#4CD964]", ringClass: "ring-green-300" },
+  { id: "orange", color: "bg-[#FF9500]", ringClass: "ring-orange-300" },
+  { id: "red", color: "bg-[#FF3B30]", ringClass: "ring-red-300" },
+];
+
 export function ThemeSelector() {
   const { theme, setTheme } = useTheme();
 
@@ -7,50 +21,20 @@ export function ThemeSelector() {
 
   return (
     <div className="flex items-center space-x-2 sm:space-x-3">
-
-
       {/* Theme Color Buttons - Hidden on mobile */}
       <div className="hidden md:flex items-center space-x-2">
-        <button
-          onClick={() => setTheme("blue")}
-          className={`w-6 h-6 rounded-full border-2 shadow-md transition-all ${
-            theme === "blue" ? "border-white ring-2 ring-blue-300" : "border-gray-300"
-          }`}
-          style={{ backgroundColor: "#007AFF" }}
-          aria-label="Blue theme"
-        />
-        <button
-          onClick={() => setTheme("pink")}
-          className={`w-6 h-6 rounded-full border-2 shadow-md transition-all ${
-            theme === "pink" ? "border-white ring-2 ring-pink-300" : "border-gray-300"
-          }`}
-          style={{ backgroundColor: "#FF2D55" }}
-          aria-label="Pink theme"
-        />
-        <button
-          onClick={() => setTheme("green")}
-          className={`w-6 h-6 rounded-full border-2 shadow-md transition-all ${
-            theme === "green" ? "border-white ring-2 ring-green-300" : "border-gray-300"
-          }`}
-          style={{ backgroundColor: "#4CD964" }}
-          aria-label="Green theme"
-        />
-        <button
-          onClick={() => setTheme("orange")}
-          className={`w-6 h-6 rounded-full border-2 shadow-md transition-all ${
-            theme === "orange" ? "border-white ring-2 ring-orange-300" : "border-gray-300"
-          }`}
-          style={{ backgroundColor: "#FF9500" }}
-          aria-label="Orange theme"
-        />
-        <button
-          onClick={() => setTheme("red")}
-          className={`w-6 h-6 rounded-full border-2 shadow-md transition-all ${
-            theme === "red" ? "border-white ring-2 ring-red-300" : "border-gray-300"
-          }`}
-          style={{ backgroundColor: "#FF3B30" }}
-          aria-label="Red theme"
-        />
+          {themeOptions.map(({ id, color, ringClass }) => (
+            <button
+              key={id}
+              onClick={() => setTheme(id)}
+              className={`w-10 h-4 rounded-full border-2 shadow-md transition-all ${color} ${
+                theme === id
+                  ? `border-white ring-2 ${ringClass}`
+                  : "border-gray-300"
+              }`}
+              aria-label={`${id.charAt(0).toUpperCase() + id.slice(1)} theme`}
+            />
+          ))}
       </div>
 
       {/* Dark mode toggle removed - app is now permanently dark theme */}


### PR DESCRIPTION
## Summary
- replace hardcoded theme buttons with a config-driven map to centralize color and ring styling
- style theme buttons with a pill shape for a softer look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab83a34e04832d86f7189e90104530