### PR TITLE
refactor: use theme tokens in font tester

### DIFF
--- a/src/components/font-tester.tsx
+++ b/src/components/font-tester.tsx
@@ -62,9 +62,9 @@ export function FontTester() {
   };
 
   return (
-    <div className="fixed top-20 right-4 z-[60] bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg border">
+    <div className="fixed top-20 right-4 z-[60] bg-card dark:bg-card p-4 rounded-lg shadow-lg border">
       <h3 className="text-sm font-medium mb-3">Font Tester</h3>
-      <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
+      <p className="text-xs text-muted-foreground mb-2">
         Current: {appliedFont}
       </p>
       <Select value={selectedFont} onValueChange={setSelectedFont}>


### PR DESCRIPTION
## Summary
- use theme token classes for font tester container background
- align font tester caption with text-muted-foreground for dark/light support

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab83a4e19c832d9499b2dc633b768a