### PR TITLE
refactor: use body data-theme for color schemes

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet">
   </head>
-  <body>
+  <body data-theme="blue">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/contexts/simple-theme-context.tsx
+++ b/src/contexts/simple-theme-context.tsx
@@ -39,12 +39,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // Apply theme class to body
   useEffect(() => {
     const body = document.body;
-    
-    // Remove any existing theme classes
-    body.classList.remove("theme-blue", "theme-pink", "theme-green", "theme-orange", "theme-red");
-    
-    // Add the current theme class
-    body.classList.add(`theme-${theme}`);
+    body.setAttribute("data-theme", theme);
   }, [theme]);
 
   const setTheme = async (newTheme: Theme) => {

--- a/src/contexts/theme-context.tsx
+++ b/src/contexts/theme-context.tsx
@@ -25,10 +25,8 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   // Initialize theme on mount
   useEffect(() => {
-    // Set initial theme class on body
-    const body = document.body;
-    body.classList.remove("theme-blue", "theme-pink", "theme-green", "theme-orange", "theme-red");
-    body.classList.add("theme-blue"); // Default theme
+    // Set default theme attribute on body
+    document.body.setAttribute("data-theme", "blue");
   }, []);
 
   // Detect if device is mobile
@@ -130,19 +128,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     }
   }, [darkMode]);
 
-  // Apply theme classes to body and document element
+  // Apply theme attribute and dark mode classes
   useEffect(() => {
     const body = document.body;
     const html = document.documentElement;
-    
-    // Remove any existing theme classes
-    body.classList.remove("theme-blue", "theme-pink", "theme-green", "theme-orange", "theme-red");
-    html.classList.remove("theme-blue", "theme-pink", "theme-green", "theme-orange", "theme-red");
-    
-    // Add the current theme class to both
-    body.classList.add(`theme-${theme}`);
-    html.classList.add(`theme-${theme}`);
-    
+
+    // Set the current theme attribute
+    body.setAttribute("data-theme", theme);
+
     // Apply dark mode to both body and html element for Tailwind compatibility
     if (darkMode) {
       body.classList.add("dark");
@@ -154,7 +147,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       html.classList.remove("dark");
       html.setAttribute("data-theme", "light");
     }
-    
+
     console.log('Applied theme:', theme, 'and dark mode:', darkMode, 'to both body and html elements');
     console.log('HTML classes:', html.className);
     console.log('Body classes:', body.className);

--- a/src/index.css
+++ b/src/index.css
@@ -77,27 +77,27 @@ input:focus-visible {
 }
 
 /* Theme color variations - iOS color palette */
-body.theme-blue {
+body[data-theme="blue"] {
   --primary: hsl(211 100% 50%) !important; /* #007AFF */
   --primary-foreground: hsl(0 0% 100%) !important;
 }
 
-body.theme-pink {
+body[data-theme="pink"] {
   --primary: hsl(343 100% 59%) !important; /* #FF2D55 */
   --primary-foreground: hsl(0 0% 100%) !important;
 }
 
-body.theme-green {
+body[data-theme="green"] {
   --primary: hsl(133 73% 63%) !important; /* #4CD964 */
   --primary-foreground: hsl(0 0% 0%) !important;
 }
 
-body.theme-orange {
+body[data-theme="orange"] {
   --primary: hsl(35 100% 50%) !important; /* #FF9500 */
   --primary-foreground: hsl(0 0% 0%) !important;
 }
 
-body.theme-red {
+body[data-theme="red"] {
   --primary: hsl(355 100% 59%) !important; /* #FF3B30 */
   --primary-foreground: hsl(0 0% 100%) !important;
 }

--- a/src/styles/fresh-dark-mode.css
+++ b/src/styles/fresh-dark-mode.css
@@ -29,7 +29,8 @@
 }
 
 /* Override the theme blue primary color for dark mode */
-.dark.theme-blue {
+body.dark[data-theme="blue"],
+.dark body[data-theme="blue"] {
   --primary: 217 91% 60%; /* Blue color that works in dark mode */
   --primary-foreground: 222.2 84% 4.9%;
 }


### PR DESCRIPTION
## Summary
- replace `theme-*` classes with `data-theme` attribute on `<body>`
- use CSS attribute selectors to define theme colors
- update theme providers to toggle `data-theme` instead of classes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab83a64e38832d9464b25e58d7d002