### PR TITLE
refactor: use theme background tokens on pages

### DIFF
--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function Landing() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
+    <div className="min-h-screen bg-background transition-colors duration-200">
       <div className="container mx-auto px-4 py-16">
         <div className="text-center mb-12">
           <div className="flex justify-center mb-6">

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -3,7 +3,7 @@ import { AlertCircle } from "lucide-react";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
+    <div className="min-h-screen w-full flex items-center justify-center bg-background">
       <Card className="w-full max-w-md mx-4">
         <CardContent className="pt-6">
           <div className="flex mb-4 gap-2">


### PR DESCRIPTION
## Summary
- replace hardcoded gray background with theme `bg-background` on landing page
- use `bg-background` on not found page

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hookform%2fresolvers)*
- `npm run build` *(fails: sh: 1: vite: not found)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab890334c0832d9cc8d08e93fdd8c4