### PR TITLE
refactor: use design tokens for text colors

### DIFF
--- a/src/components/export-buttons.tsx
+++ b/src/components/export-buttons.tsx
@@ -32,7 +32,7 @@ export function ExportButtons({ data }: ExportButtonsProps) {
         <Button 
           variant="ghost" 
           size="sm"
-          className="text-gray-600 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-200 touch-manipulation"
+          className="text-muted-foreground hover:text-foreground touch-manipulation"
         >
           <Download className="h-4 w-4 mr-1 sm:mr-2" />
           <span className="hidden sm:inline">Export</span>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -335,7 +335,7 @@ export default function Home() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <Calculator className="h-8 w-8 animate-spin text-primary mx-auto mb-4" />
-          <p className="text-gray-600 dark:text-gray-300">Loading your financial data...</p>
+          <p className="text-muted-foreground">Loading your financial data...</p>
         </div>
       </div>
     );
@@ -583,7 +583,7 @@ export default function Home() {
           <DialogHeader>
             <DialogTitle>Clear All Data</DialogTitle>
           </DialogHeader>
-          <p className="text-gray-600 dark:text-gray-300">
+          <p className="text-muted-foreground">
             Are you sure you want to clear all financial data? This action cannot be undone.
           </p>
           <DialogFooter>

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -10,10 +10,10 @@ export default function Landing() {
           <div className="flex justify-center mb-6">
             <Calculator className="h-16 w-16 text-primary" />
           </div>
-          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+          <h1 className="text-4xl font-bold text-foreground mb-4">
             Financial Position Calculator
           </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
             Quickly calculate your current financial position with cash counting, 
             weekly income and expense tracking, and automated balance calculations.
           </p>
@@ -28,7 +28,7 @@ export default function Landing() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-600 dark:text-gray-300">
+              <p className="text-muted-foreground">
                 Count Australian notes and coins with automatic subtotals and total calculation.
               </p>
             </CardContent>
@@ -39,7 +39,7 @@ export default function Landing() {
               <CardTitle className="text-primary">Weekly Tracking</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-600 dark:text-gray-300">
+              <p className="text-muted-foreground">
                 Track income and expenses for current and next week with customizable categories.
               </p>
             </CardContent>
@@ -50,7 +50,7 @@ export default function Landing() {
               <CardTitle className="text-primary">Auto Calculations</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-600 dark:text-gray-300">
+              <p className="text-muted-foreground">
                 Real-time calculations cascade from cash counter through to final weekly balances.
               </p>
             </CardContent>
@@ -65,7 +65,7 @@ export default function Landing() {
           >
             Get Started - Sign In
           </Button>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-4">
+          <p className="text-sm text-muted-foreground mt-4">
             Your data will be securely saved and synced across devices
           </p>
         </div>

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -8,10 +8,10 @@ export default function NotFound() {
         <CardContent className="pt-6">
           <div className="flex mb-4 gap-2">
             <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+            <h1 className="text-2xl font-bold text-foreground">404 Page Not Found</h1>
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
+          <p className="mt-4 text-sm text-muted-foreground">
             Did you forget to add the page to the router?
           </p>
         </CardContent>


### PR DESCRIPTION
## Summary
- replace legacy gray text classes with design tokens
- update export button hover style to use foreground token

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab88e4f1d8832daac4de3fda98291e