### PR TITLE
chore: set up vitest testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Fintrak
+
+This project uses [Vite](https://vitejs.dev/) and React.
+
+## Testing
+
+Vitest is configured for unit testing.
+
+After installing dependencies, run:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "vite build",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -51,6 +51,7 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.3",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { formatCurrency } from "@/lib/utils";
+
+describe("formatCurrency", () => {
+  it("formats numbers into USD currency", () => {
+    expect(formatCurrency(1234.56)).toBe("$1,234.56");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+    },
+  })
+);


### PR DESCRIPTION
## Summary
- add Vitest config and sample test
- document how to run tests in README

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8bcee7b4832da41672affa5ba421