### PR TITLE
fix dark mode primary color

### DIFF
--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -8,7 +8,7 @@
   --card-foreground: 210 40% 98%;
   --popover: 222.2 84% 4.9%;
   --popover-foreground: 210 40% 98%;
-  --primary: 210 40% 98%;
+  --primary: 217 91% 60%;
   --primary-foreground: 222.2 84% 4.9%;
   --secondary: 217.2 32.6% 17.5%;
   --secondary-foreground: 210 40% 98%;


### PR DESCRIPTION
## Summary
- ensure dark theme keeps blue `--primary` value so border-primary stays blue

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8fbefe40832d8ee7206ade943dd9