### PR TITLE
refactor: consolidate body styles and remove !important

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,11 +4,6 @@
 
 @import "./styles/dark-mode.css";
 
-body {
-  color: hsl(var(--foreground));
-  background: hsl(var(--background));
-}
-
 :root {
   --background: 222.2 84% 4.9%;
   --foreground: 210 40% 85%;
@@ -35,89 +30,85 @@ body {
 
 /* Override input styling for dark theme */
 .dark-input {
-  background-color: hsl(var(--input)) !important;
-  color: hsl(var(--foreground)) !important;
-  border: 0.5px solid hsl(var(--primary) / 0.7) !important;
+  @apply bg-input text-foreground border-[0.5px] border-primary/70;
 }
 
 
 /* Ensure proper text contrast */
 .text-muted {
-  color: hsl(var(--muted-foreground)) !important;
+  @apply text-muted-foreground;
 }
 
 /* Theme color variations - iOS color palette */
 body[data-theme="blue"] {
-  --primary: hsl(211 100% 50%) !important; /* #007AFF */
-  --primary-foreground: hsl(0 0% 100%) !important;
+  --primary: hsl(211 100% 50%); /* #007AFF */
+  --primary-foreground: hsl(0 0% 100%);
 }
 
 body[data-theme="pink"] {
-  --primary: hsl(343 100% 59%) !important; /* #FF2D55 */
-  --primary-foreground: hsl(0 0% 100%) !important;
+  --primary: hsl(343 100% 59%); /* #FF2D55 */
+  --primary-foreground: hsl(0 0% 100%);
 }
 
 body[data-theme="green"] {
-  --primary: hsl(133 73% 63%) !important; /* #4CD964 */
-  --primary-foreground: hsl(0 0% 0%) !important;
+  --primary: hsl(133 73% 63%); /* #4CD964 */
+  --primary-foreground: hsl(0 0% 0%);
 }
 
 body[data-theme="orange"] {
-  --primary: hsl(35 100% 50%) !important; /* #FF9500 */
-  --primary-foreground: hsl(0 0% 0%) !important;
+  --primary: hsl(35 100% 50%); /* #FF9500 */
+  --primary-foreground: hsl(0 0% 0%);
 }
 
 body[data-theme="red"] {
-  --primary: hsl(355 100% 59%) !important; /* #FF3B30 */
-  --primary-foreground: hsl(0 0% 100%) !important;
+  --primary: hsl(355 100% 59%); /* #FF3B30 */
+  --primary-foreground: hsl(0 0% 100%);
 }
 
 /* Enhanced contrast for mobile light mode */
 @media (max-width: 768px) {
   :not(.dark) .text-gray-500 {
-    color: hsl(210 25% 40%) !important;
+    color: hsl(210 25% 40%);
   }
-  
-  :not(.dark) .text-gray-600 {
-    color: hsl(210 25% 30%) !important;
-  }
-  
-  :not(.dark) .text-gray-700 {
-    color: hsl(210 25% 20%) !important;
-  }
-  
-  :not(.dark) .border-gray-200 {
-    border-color: hsl(210 25% 75%) !important;
-  }
-  
-  :not(.dark) .border-gray-300 {
-    border-color: hsl(210 25% 65%) !important;
-  }
-  
-  :not(.dark) .bg-gray-50 {
-    background-color: hsl(210 25% 96%) !important;
-  }
-  
-  :not(.dark) .bg-gray-100 {
-    background-color: hsl(210 25% 90%) !important;
-  }
-}
 
-/* Space Grotesk font applied globally */
-body {
-  font-family: 'Space Grotesk', 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  :not(.dark) .text-gray-600 {
+    color: hsl(210 25% 30%);
+  }
+
+  :not(.dark) .text-gray-700 {
+    color: hsl(210 25% 20%);
+  }
+
+  :not(.dark) .border-gray-200 {
+    border-color: hsl(210 25% 75%);
+  }
+
+  :not(.dark) .border-gray-300 {
+    border-color: hsl(210 25% 65%);
+  }
+
+  :not(.dark) .bg-gray-50 {
+    background-color: hsl(210 25% 96%);
+  }
+
+  :not(.dark) .bg-gray-100 {
+    background-color: hsl(210 25% 90%);
+  }
 }
 
 @layer base {
+  /* Space Grotesk font applied globally */
   body {
-    @apply font-sans antialiased bg-background text-foreground;
+    @apply font-sans antialiased;
     font-family: "Space Grotesk", var(--font-sans), sans-serif;
+    color: hsl(var(--foreground));
+    background: hsl(var(--background));
   }
 
   /* Mobile optimizations */
   @media (max-width: 768px) {
     input, select, button {
-      font-size: 16px !important; /* Prevents zoom on iOS */
+      font-size: 16px; /* Prevents zoom on iOS */
       min-height: 44px; /* iOS recommended touch target size */
     }
     

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -35,12 +35,7 @@ body.dark[data-theme="blue"],
   --primary-foreground: 222.2 84% 4.9%;
 }
 
-/* Ensure proper background and text colors */
-.dark {
-  background-color: hsl(var(--background));
-  color: hsl(var(--foreground));
-}
-
+/* Ensure elements use dark theme borders */
 .dark * {
   border-color: hsl(var(--border));
 }
@@ -93,11 +88,4 @@ body.dark[data-theme="blue"],
 /* Border colors */
 .dark .border-border {
   border-color: hsl(var(--border));
-}
-
-/* Make sure the main page background is dark */
-.dark body,
-.dark #root,
-.dark main {
-  background-color: hsl(var(--background));
 }


### PR DESCRIPTION
## Summary
- Consolidate body styling into base layer and remove duplicate top-level block
- Replace `!important` rules with Tailwind utilities and specific selectors
- Simplify dark mode CSS to rely on shared variables without redefining body styles

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab91b4b224832d90e828865afda03a