### PR TITLE
refactor: centralize theme colors

### DIFF
--- a/src/components/theme-selector.tsx
+++ b/src/components/theme-selector.tsx
@@ -1,18 +1,8 @@
+import React from "react";
 import { useTheme } from "@/contexts/simple-theme-context";
+import { themeColors, getRingColor, Theme } from "@/constants/theme";
 
-type ThemeOption = {
-  id: "blue" | "pink" | "green" | "orange" | "red";
-  color: string;
-  ringClass: string;
-};
-
-const themeOptions: ThemeOption[] = [
-  { id: "blue", color: "bg-[#007AFF]", ringClass: "ring-blue-300" },
-  { id: "pink", color: "bg-[#FF2D55]", ringClass: "ring-pink-300" },
-  { id: "green", color: "bg-[#4CD964]", ringClass: "ring-green-300" },
-  { id: "orange", color: "bg-[#FF9500]", ringClass: "ring-orange-300" },
-  { id: "red", color: "bg-[#FF3B30]", ringClass: "ring-red-300" },
-];
+const themeOptions = Object.keys(themeColors) as Theme[];
 
 export function ThemeSelector() {
   const { theme, setTheme } = useTheme();
@@ -23,18 +13,25 @@ export function ThemeSelector() {
     <div className="flex items-center space-x-2 sm:space-x-3">
       {/* Theme Color Buttons - Hidden on mobile */}
       <div className="hidden md:flex items-center space-x-2">
-          {themeOptions.map(({ id, color, ringClass }) => (
+        {themeOptions.map((id) => {
+          const ring = getRingColor(id);
+          return (
             <button
               key={id}
+              data-theme={id}
               onClick={() => setTheme(id)}
-              className={`w-10 h-4 rounded-full border-2 shadow-md transition-all ${color} ${
-                theme === id
-                  ? `border-white ring-2 ${ringClass}`
-                  : "border-gray-300"
+              style={{
+                // Provide color tokens for tailwind utility classes
+                "--primary": themeColors[id],
+                ...(theme === id ? { "--tw-ring-color": ring } : {}),
+              } as React.CSSProperties}
+              className={`w-10 h-4 rounded-full border-2 shadow-md transition-all bg-primary ${
+                theme === id ? "border-white ring-2" : "border-gray-300"
               }`}
               aria-label={`${id.charAt(0).toUpperCase() + id.slice(1)} theme`}
             />
-          ))}
+          );
+        })}
       </div>
 
       {/* Dark mode toggle removed - app is now permanently dark theme */}

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,0 +1,35 @@
+export type Theme = "blue" | "pink" | "green" | "orange" | "red";
+
+export const themeColors: Record<Theme, string> = {
+  blue: "#007AFF",
+  pink: "#FF2D55",
+  green: "#4CD964",
+  orange: "#FF9500",
+  red: "#FF3B30",
+};
+
+function hexToRgb(hex: string): [number, number, number] {
+  const cleaned = hex.replace(/^#/, "");
+  const bigint = parseInt(cleaned, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return [r, g, b];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b]
+    .map((x) => {
+      const hex = Math.round(x).toString(16);
+      return hex.length === 1 ? "0" + hex : hex;
+    })
+    .join("")}`;
+}
+
+export function getRingColor(theme: Theme, amount = 0.5): string {
+  const [r, g, b] = hexToRgb(themeColors[theme]);
+  const ringR = r + (255 - r) * amount;
+  const ringG = g + (255 - g) * amount;
+  const ringB = b + (255 - b) * amount;
+  return rgbToHex(ringR, ringG, ringB);
+}


### PR DESCRIPTION
## Summary
- add shared theme color constants with helper to derive ring color
- update theme selector to use token-based `bg-primary` classes and compute ring colors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab930c2c44832d8d0453d0a4d6354f