### PR TITLE
refactor: move sidebar and progress styles into css variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ After installing dependencies, run:
 ```bash
 npm test
 ```
+
+## Styling guidelines
+
+The `Sidebar` and `Progress` components rely on CSS variables defined in
+`src/styles/sidebar.css` and in component classes. To customize widths or
+progress animations, override these variables in your own stylesheet or extend
+Tailwind's theme. For example, modify `--sidebar-width` to change sidebar size
+or `--progress-translate` to tweak progress indicator movement. Keeping these
+values in CSS discourages inline styles and makes theming easier.
+

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -18,8 +18,10 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      className="h-full w-full flex-1 bg-primary transition-all [transform:translateX(var(--progress-translate))]"
+      style={{
+        "--progress-translate": `-${100 - (value || 0)}%`,
+      } as React.CSSProperties}
     />
   </ProgressPrimitive.Root>
 ))

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -25,9 +25,6 @@ import {
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
-const SIDEBAR_WIDTH = "16rem"
-const SIDEBAR_WIDTH_MOBILE = "18rem"
-const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 type SidebarContextProps = {
@@ -137,15 +134,9 @@ const SidebarProvider = React.forwardRef<
       <SidebarContext.Provider value={contextValue}>
         <TooltipProvider delayDuration={0}>
           <div
-            style={
-              {
-                "--sidebar-width": SIDEBAR_WIDTH,
-                "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-                ...style,
-              } as React.CSSProperties
-            }
+            style={style}
             className={cn(
-              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper sidebar-vars flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
               className
             )}
             ref={ref}
@@ -202,12 +193,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
-            style={
-              {
-                "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
-              } as React.CSSProperties
-            }
+            className="sidebar-vars-mobile w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
             side={side}
           >
             <SheetHeader className="sr-only">

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 @import "./styles/dark-mode.css";
+@import "./styles/sidebar.css";
 
 :root {
   --background: 222.2 84% 4.9%;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1,0 +1,9 @@
+/* Sidebar variable definitions */
+.sidebar-vars {
+  --sidebar-width: 16rem;
+  --sidebar-width-icon: 3rem;
+}
+
+.sidebar-vars-mobile {
+  --sidebar-width: 18rem;
+}


### PR DESCRIPTION
## Summary
- replace inline progress indicator transform with CSS variable
- move sidebar width variables into a shared stylesheet and reference via classes
- document how to customize sidebar and progress variables

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab93ee73a8832d8b25122fcb677831