### PR TITLE
refactor: update primary border styling

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border-[0.5px] border-primary/70 bg-card text-card-foreground shadow-sm",
+      "rounded-lg border-[0.5px] border-primary border-opacity-70 bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border-[0.5px] border-primary/70 bg-input px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border-[0.5px] border-primary border-opacity-70 bg-input px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import "./styles/dark-mode.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import "./styles/dark-mode.css";
 
 :root {
   --background: 222.2 84% 4.9%;
@@ -30,7 +30,7 @@
 
 /* Override input styling for dark theme */
 .dark-input {
-  @apply bg-input text-foreground border-[0.5px] border-primary/70;
+  @apply bg-input text-foreground border-[0.5px] border-primary border-opacity-70;
 }
 
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,5 @@
-const test = require('node:test')
-const assert = require('node:assert')
+import { test, expect } from 'vitest'
 
 test('sanity check', () => {
-  assert.strictEqual(true, true)
+  expect(true).toBe(true)
 })


### PR DESCRIPTION
## Summary
- update dark-input utility and import order for Tailwind
- replace `border-primary/70` with `border-primary border-opacity-70`
- convert Node test to Vitest

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab96919a7c832d8484416647b9a161