### PR TITLE
fix dark mode focus ring color

### DIFF
--- a/src/__tests__/dark-mode.test.ts
+++ b/src/__tests__/dark-mode.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+
+describe("dark mode focus ring", () => {
+  it("uses Tailwind ring color variable", () => {
+    const cssPath = path.resolve(__dirname, "../styles/dark-mode.css");
+    const css = fs.readFileSync(cssPath, "utf8");
+    const match = /\.dark\s+input:focus\s*\{([^}]+)\}/.exec(css);
+    expect(match).not.toBeNull();
+    expect(match![1]).toContain("--tw-ring-color: hsl(var(--ring));");
+  });
+});

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -54,7 +54,7 @@ body.dark[data-theme="blue"],
 }
 
 .dark input:focus {
-  ring-color: hsl(var(--ring));
+  --tw-ring-color: hsl(var(--ring));
 }
 
 /* Button styling */


### PR DESCRIPTION
## Summary
- use Tailwind ring color variable for dark mode input focus
- add test covering dark mode focus ring styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab9b5400f4832d831938a5531e1d8d