### PR TITLE
feat: add token classes and button variants

### DIFF
--- a/src/components/bank-accounts.tsx
+++ b/src/components/bank-accounts.tsx
@@ -125,7 +125,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
                 variant="ghost"
                 size="sm"
                 onClick={() => removeBankAccountRow(row.id)}
-                className="text-red-500 hover:text-red-700 p-2 touch-manipulation"
+                className="text-destructive hover:text-destructive/80 p-2 touch-manipulation"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/src/components/font-tester.tsx
+++ b/src/components/font-tester.tsx
@@ -62,9 +62,9 @@ export function FontTester() {
   };
 
   return (
-    <div className="fixed top-20 right-4 z-[60] bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg border border-primary">
+    <div className="fixed top-20 right-4 z-[60] bg-card p-4 rounded-lg shadow-lg border border-primary">
       <h3 className="text-sm font-medium mb-3">Font Tester</h3>
-      <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
+      <p className="text-xs text-muted-foreground mb-2">
         Current: {appliedFont}
       </p>
       <Select value={selectedFont} onValueChange={setSelectedFont}>

--- a/src/components/quick-add-shortcuts.tsx
+++ b/src/components/quick-add-shortcuts.tsx
@@ -60,10 +60,10 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
               {INCOME_SHORTCUTS.map((shortcut, index) => (
                 <Button
                   key={`${shortcut.label}-${shortcut.amount}-${index}`}
-                  variant="outline"
+                  variant="income"
                   size="sm"
                   onClick={() => onAddIncome(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2 bg-green-50 hover:bg-green-100 dark:bg-green-950/50 dark:hover:bg-green-900/50 border-green-200 dark:border-green-800 text-green-700 dark:text-green-300 touch-manipulation"
+                  className="text-xs h-7 px-2 touch-manipulation"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">
@@ -81,10 +81,10 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
               {EXPENSE_SHORTCUTS.map((shortcut, index) => (
                 <Button
                   key={`${shortcut.label}-${shortcut.amount}-${index}`}
-                  variant="outline"
+                  variant="expense"
                   size="sm"
                   onClick={() => onAddExpense(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2 bg-red-50 hover:bg-red-100 dark:bg-red-950/50 dark:hover:bg-red-900/50 border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 touch-manipulation"
+                  className="text-xs h-7 px-2 touch-manipulation"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,6 +18,10 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        income:
+          "bg-green-50 hover:bg-green-100 border border-green-200 text-green-700 dark:bg-green-950/50 dark:hover:bg-green-900/50 dark:border-green-800 dark:text-green-300",
+        expense:
+          "bg-red-50 hover:bg-red-100 border border-red-200 text-red-700 dark:bg-red-950/50 dark:hover:bg-red-900/50 dark:border-red-800 dark:text-red-300",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
## Summary
- replace explicit danger styles with tokenized classes
- add income/expense button variants and use them for quick adds
- switch font tester to card and muted tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba026dbf4832d99f5304e4d223226