### PR TITLE
feat: default touch manipulation for inputs and buttons

### DIFF
--- a/src/__tests__/mobile-interactions.test.tsx
+++ b/src/__tests__/mobile-interactions.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { renderToString } from "react-dom/server";
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+describe("mobile interaction styles", () => {
+  it("Button includes touch manipulation styles", () => {
+    const html = renderToString(<Button>Test</Button>);
+    expect(html).toContain("touch-manipulation");
+    expect(html).toContain("-webkit-tap-highlight-color:transparent");
+  });
+
+  it("Input includes touch manipulation styles", () => {
+    const html = renderToString(<Input />);
+    expect(html).toContain("touch-manipulation");
+    expect(html).toContain("-webkit-tap-highlight-color:transparent");
+  });
+});

--- a/src/components/bank-accounts.tsx
+++ b/src/components/bank-accounts.tsx
@@ -92,7 +92,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
             <div className="text-lg font-bold text-primary">
               {formatCurrency(totalBalance)}
             </div>
-            <Button onClick={addBankAccountRow} size="sm" className="bg-primary text-white touch-manipulation">
+            <Button onClick={addBankAccountRow} size="sm" className="bg-primary text-white">
               <Plus className="h-4 w-4 mr-1" />
               <span className="hidden sm:inline">Add Account</span>
               <span className="sm:hidden">Add</span>
@@ -107,7 +107,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
                 value={row.label}
                 onChange={(e) => updateBankAccountRow(row.id, 'label', e.target.value)}
                 placeholder="Account name..."
-                className="flex-1 text-base sm:text-sm touch-manipulation"
+                className="flex-1 text-base sm:text-sm"
               />
               <div className="relative">
                 <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">$</span>
@@ -117,7 +117,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
                   value={row.amount || ""}
                   onChange={(e) => updateBankAccountRow(row.id, 'amount', parseFloat(e.target.value) || 0)}
                   placeholder="0.00"
-                  className="w-28 sm:w-32 pl-8 text-right text-base sm:text-sm touch-manipulation"
+                  className="w-28 sm:w-32 pl-8 text-right text-base sm:text-sm"
                   step="0.01"
                 />
               </div>
@@ -125,7 +125,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
                 variant="ghost"
                 size="sm"
                 onClick={() => removeBankAccountRow(row.id)}
-                className="text-destructive hover:text-destructive/80 p-2 touch-manipulation"
+                className="text-destructive hover:text-destructive/80 p-2"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/src/components/cash-calculator.tsx
+++ b/src/components/cash-calculator.tsx
@@ -84,7 +84,7 @@ export function CashCalculator({ denominations, onUpdate }: CashCalculatorProps)
                     inputMode="numeric"
                     value={quantity || ""}
                     onChange={(e) => updateDenomination(note.key, parseInt(e.target.value) || 0)}
-                    className="w-16 sm:w-16 text-right text-base sm:text-sm touch-manipulation bg-input text-foreground border-border"
+                    className="w-16 sm:w-16 text-right text-base sm:text-sm bg-input text-foreground border-border"
                     min="0"
                     placeholder="0"
                   />
@@ -129,7 +129,7 @@ export function CashCalculator({ denominations, onUpdate }: CashCalculatorProps)
                     inputMode="numeric"
                     value={quantity || ""}
                     onChange={(e) => updateDenomination(coin.key, parseInt(e.target.value) || 0)}
-                    className="w-16 sm:w-16 text-right text-base sm:text-sm touch-manipulation bg-input text-foreground border-border"
+                    className="w-16 sm:w-16 text-right text-base sm:text-sm bg-input text-foreground border-border"
                     min="0"
                     placeholder="0"
                   />

--- a/src/components/export-buttons.tsx
+++ b/src/components/export-buttons.tsx
@@ -32,7 +32,7 @@ export function ExportButtons({ data }: ExportButtonsProps) {
         <Button 
           variant="ghost" 
           size="sm"
-          className="text-muted-foreground hover:text-foreground touch-manipulation"
+          className="text-muted-foreground hover:text-foreground"
         >
           <Download className="h-4 w-4 mr-1 sm:mr-2" />
           <span className="hidden sm:inline">Export</span>

--- a/src/components/quick-add-shortcuts.tsx
+++ b/src/components/quick-add-shortcuts.tsx
@@ -38,7 +38,7 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
       {/* Collapsible Header */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-3 text-left hover:bg-primary/10 dark:hover:bg-primary/20 rounded-lg transition-colors touch-manipulation"
+        className="w-full flex items-center justify-between p-3 text-left hover:bg-primary/10 dark:hover:bg-primary/20 rounded-lg transition-colors touch-manipulation [-webkit-tap-highlight-color:transparent]"
       >
         <h3 className="text-sm font-medium text-primary dark:text-primary">
           Quick Add - Week {weekNumber}
@@ -63,7 +63,7 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
                   variant="income"
                   size="sm"
                   onClick={() => onAddIncome(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2 touch-manipulation"
+                  className="text-xs h-7 px-2"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">
@@ -84,7 +84,7 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
                   variant="expense"
                   size="sm"
                   onClick={() => onAddExpense(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2 touch-manipulation"
+                  className="text-xs h-7 px-2"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation [-webkit-tap-highlight-color:transparent]",
   {
     variants: {
       variant: {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border-[0.5px] border-primary border-opacity-70 bg-input px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border-[0.5px] border-primary border-opacity-70 bg-input px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 md:text-sm touch-manipulation [-webkit-tap-highlight-color:transparent]",
           className
         )}
         ref={ref}

--- a/src/components/week-calculator.tsx
+++ b/src/components/week-calculator.tsx
@@ -230,7 +230,7 @@ export function WeekCalculator({
             <h3 className="text-sm font-medium text-muted-foreground">
               Income {weekNumber === 1 ? "This Week" : "Next Week"}
             </h3>
-            <Button onClick={addIncomeRow} size="sm" className="bg-primary text-white touch-manipulation">
+            <Button onClick={addIncomeRow} size="sm" className="bg-primary text-white">
               <Plus className="h-4 w-4 mr-1" />
               <span className="hidden sm:inline">Add Row</span>
               <span className="sm:hidden">Add</span>
@@ -243,7 +243,7 @@ export function WeekCalculator({
                   value={row.label}
                   onChange={(e) => updateIncomeRow(row.id, 'label', e.target.value)}
                   placeholder="Income source..."
-                  className="flex-1 text-base sm:text-sm touch-manipulation bg-input text-foreground border-border"
+                  className="flex-1 text-base sm:text-sm bg-input text-foreground border-border"
                 />
                 <div className="relative">
                   <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">$</span>
@@ -253,7 +253,7 @@ export function WeekCalculator({
                     value={row.amount || ""}
                     onChange={(e) => updateIncomeRow(row.id, 'amount', parseFloat(e.target.value) || 0)}
                     placeholder="0.00"
-                    className="w-28 sm:w-32 pl-8 text-right text-base sm:text-sm touch-manipulation bg-input text-foreground border-border"
+                    className="w-28 sm:w-32 pl-8 text-right text-base sm:text-sm bg-input text-foreground border-border"
                     step="0.01"
                   />
                 </div>
@@ -261,7 +261,7 @@ export function WeekCalculator({
                   variant="ghost"
                   size="sm"
                   onClick={() => removeIncomeRow(row.id)}
-                  className="text-destructive hover:text-destructive/80 p-2 touch-manipulation"
+                  className="text-destructive hover:text-destructive/80 p-2"
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
@@ -282,7 +282,7 @@ export function WeekCalculator({
             <h3 className="text-sm font-medium text-muted-foreground">
               Expenses {weekNumber === 1 ? "This Week" : "Next Week"}
             </h3>
-            <Button onClick={addExpenseRow} size="sm" className="bg-primary text-white touch-manipulation">
+            <Button onClick={addExpenseRow} size="sm" className="bg-primary text-white">
               <Plus className="h-4 w-4 mr-1" />
               <span className="hidden sm:inline">Add Row</span>
               <span className="sm:hidden">Add</span>
@@ -295,7 +295,7 @@ export function WeekCalculator({
                   value={row.label}
                   onChange={(e) => updateExpenseRow(row.id, 'label', e.target.value)}
                   placeholder="Expense item..."
-                  className="flex-1 text-base sm:text-sm touch-manipulation bg-input text-foreground border-border"
+                  className="flex-1 text-base sm:text-sm bg-input text-foreground border-border"
                 />
                 <div className="relative">
                   <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground">$</span>
@@ -305,7 +305,7 @@ export function WeekCalculator({
                     value={row.amount || ""}
                     onChange={(e) => updateExpenseRow(row.id, 'amount', parseFloat(e.target.value) || 0)}
                     placeholder="0.00"
-                    className="w-28 sm:w-32 pl-8 text-right text-base sm:text-sm touch-manipulation bg-input text-foreground border-border"
+                    className="w-28 sm:w-32 pl-8 text-right text-base sm:text-sm bg-input text-foreground border-border"
                     step="0.01"
                   />
                 </div>
@@ -313,7 +313,7 @@ export function WeekCalculator({
                   variant="ghost"
                   size="sm"
                   onClick={() => removeExpenseRow(row.id)}
-                  className="text-destructive hover:text-destructive/80 p-2 touch-manipulation"
+                  className="text-destructive hover:text-destructive/80 p-2"
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -112,11 +112,6 @@ body[data-theme="red"] {
       min-height: 44px; /* iOS recommended touch target size */
     }
     
-    /* Improve touch targets */
-    .touch-manipulation {
-      touch-action: manipulation;
-      -webkit-tap-highlight-color: transparent;
-    }
   }
 
   /* iOS specific optimizations */


### PR DESCRIPTION
## Summary
- add default touch-action and tap highlight reset to base Button and Input components
- clean up redundant `touch-manipulation` classes across calculators and export UI
- add tests ensuring components include mobile interaction styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba0c3dcd0832da3d626547de0d685