### PR TITLE
refactor: remove redundant button colors

### DIFF
--- a/src/components/bank-accounts.tsx
+++ b/src/components/bank-accounts.tsx
@@ -92,7 +92,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
             <div className="text-lg font-bold text-primary">
               {formatCurrency(totalBalance)}
             </div>
-            <Button onClick={addBankAccountRow} size="sm" className="bg-primary text-white">
+            <Button onClick={addBankAccountRow} size="sm">
               <Plus className="h-4 w-4 mr-1" />
               <span className="hidden sm:inline">Add Account</span>
               <span className="sm:hidden">Add</span>

--- a/src/components/inventory-tracker.tsx
+++ b/src/components/inventory-tracker.tsx
@@ -196,9 +196,8 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
           </div>
           <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
             <DialogTrigger asChild>
-              <Button 
-                size="sm" 
-                className="bg-primary text-primary-foreground hover:bg-primary/90"
+              <Button
+                size="sm"
                 onClick={() => {
                   setEditingBatch(null);
                   resetForm();
@@ -326,9 +325,8 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                   >
                     Cancel
                   </Button>
-                  <Button 
-                    type="submit" 
-                    className="bg-primary text-primary-foreground hover:bg-primary/90"
+                  <Button
+                    type="submit"
                     disabled={saveBatchMutation.isPending}
                   >
                     {saveBatchMutation.isPending ? "Saving..." : editingBatch ? "Update" : "Add"} Batch

--- a/src/components/sales-tracker.tsx
+++ b/src/components/sales-tracker.tsx
@@ -245,9 +245,8 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
           </div>
           <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
             <DialogTrigger asChild>
-              <Button 
-                size="sm" 
-                className="bg-primary text-primary-foreground hover:bg-primary/90"
+              <Button
+                size="sm"
                 onClick={resetForm}
               >
                 <Plus className="h-4 w-4 mr-1" />
@@ -373,9 +372,8 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                   >
                     Cancel
                   </Button>
-                  <Button 
-                    type="submit" 
-                    className="bg-primary text-primary-foreground hover:bg-primary/90"
+                  <Button
+                    type="submit"
                     disabled={addSaleMutation.isPending}
                   >
                     {addSaleMutation.isPending ? "Saving..." : "Record Sale"}

--- a/src/components/week-calculator.tsx
+++ b/src/components/week-calculator.tsx
@@ -230,7 +230,7 @@ export function WeekCalculator({
             <h3 className="text-sm font-medium text-muted-foreground">
               Income {weekNumber === 1 ? "This Week" : "Next Week"}
             </h3>
-            <Button onClick={addIncomeRow} size="sm" className="bg-primary text-white">
+            <Button onClick={addIncomeRow} size="sm">
               <Plus className="h-4 w-4 mr-1" />
               <span className="hidden sm:inline">Add Row</span>
               <span className="sm:hidden">Add</span>
@@ -282,7 +282,7 @@ export function WeekCalculator({
             <h3 className="text-sm font-medium text-muted-foreground">
               Expenses {weekNumber === 1 ? "This Week" : "Next Week"}
             </h3>
-            <Button onClick={addExpenseRow} size="sm" className="bg-primary text-white">
+            <Button onClick={addExpenseRow} size="sm">
               <Plus className="h-4 w-4 mr-1" />
               <span className="hidden sm:inline">Add Row</span>
               <span className="sm:hidden">Add</span>

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -58,10 +58,10 @@ export default function Landing() {
         </div>
 
         <div className="text-center">
-          <Button 
+          <Button
             onClick={() => window.location.href = '/api/login'}
             size="lg"
-            className="bg-primary hover:bg-primary/90 text-white px-8 py-3 text-lg"
+            className="px-8 py-3 text-lg"
           >
             Get Started - Sign In
           </Button>

--- a/src/pages/login-page-netlify.tsx
+++ b/src/pages/login-page-netlify.tsx
@@ -104,9 +104,9 @@ export default function LoginPage() {
               </div>
             </div>
             
-            <Button 
-              type="submit" 
-              className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
+            <Button
+              type="submit"
+              className="w-full"
               disabled={isLoading}
             >
               {isLoading ? "Signing in..." : "Sign In"}

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -110,9 +110,9 @@ export default function LoginPage() {
                 </div>
               </div>
               
-              <Button 
-                type="submit" 
-                className="w-full bg-primary text-white hover:bg-primary/90"
+              <Button
+                type="submit"
+                className="w-full"
                 disabled={loginMutation.isPending}
               >
                 {loginMutation.isPending ? (


### PR DESCRIPTION
## Summary
- remove inline `bg-primary`/`text-white` on buttons in favor of component variants
- simplify login and landing buttons to rely on default styling
- clean up add/edit forms for sales and inventory trackers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba34e08e8832d8b3f360c0cc1f54e