### PR TITLE
refactor: unify secondary text color

### DIFF
--- a/src/components/bank-accounts.tsx
+++ b/src/components/bank-accounts.tsx
@@ -85,7 +85,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
         <div className="flex items-center justify-between">
           <div className="flex items-center">
             <Building2 className="mr-3 h-5 w-5 text-primary" />
-            <h3 className="text-sm font-medium text-foreground/85">
+            <h3 className="text-sm font-medium text-muted-foreground">
               Bank Accounts
             </h3>
           </div>
@@ -138,7 +138,7 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
         {bankAccountRows.length > 0 && (
           <div className="border-t border-border pt-3">
             <div className="flex justify-between items-center">
-              <span className="text-sm font-medium text-foreground/85">
+              <span className="text-sm font-medium text-muted-foreground">
                 Total Bank Balance:
               </span>
               <span className="text-sm font-semibold text-primary">

--- a/src/components/inventory-tracker.tsx
+++ b/src/components/inventory-tracker.tsx
@@ -193,7 +193,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Package className="h-5 w-5 text-primary" />
-            <CardTitle className="text-foreground/85">Inventory Tracker</CardTitle>
+            <CardTitle className="text-muted-foreground">Inventory Tracker</CardTitle>
           </div>
           <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
             <DialogTrigger asChild>
@@ -210,14 +210,14 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
             </DialogTrigger>
             <DialogContent className="bg-background border-2 border-primary/20">
               <DialogHeader>
-                <DialogTitle className="text-foreground/85">
+                <DialogTitle className="text-muted-foreground">
                   {editingBatch ? "Edit Batch" : "Add New Batch"}
                 </DialogTitle>
               </DialogHeader>
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="batchName" className="text-sm text-foreground/85">
+                    <Label htmlFor="batchName" className="text-sm text-muted-foreground">
                       Batch Name
                     </Label>
                     <Input
@@ -230,7 +230,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="productName" className="text-sm text-foreground/85">
+                    <Label htmlFor="productName" className="text-sm text-muted-foreground">
                       Product Name
                     </Label>
                     <Input
@@ -246,7 +246,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                 
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="totalPricePaid" className="text-sm text-foreground/85">
+                    <Label htmlFor="totalPricePaid" className="text-sm text-muted-foreground">
                       Total Price Paid
                     </Label>
                     <CurrencyInput
@@ -258,7 +258,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="numberOfUnits" className="text-sm text-foreground/85">
+                    <Label htmlFor="numberOfUnits" className="text-sm text-muted-foreground">
                       Number of Units
                     </Label>
                     <Input
@@ -275,7 +275,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
 
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="projectedSaleCostPerUnit" className="text-sm text-foreground/85">
+                    <Label htmlFor="projectedSaleCostPerUnit" className="text-sm text-muted-foreground">
                       Projected Sale Price Per Unit
                     </Label>
                     <CurrencyInput
@@ -287,8 +287,8 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label className="text-sm text-foreground/85">Unit Cost (Auto)</Label>
-                    <div className="flex items-center h-10 px-3 rounded-md border border-primary/30 bg-muted text-foreground/85">
+                    <Label className="text-sm text-muted-foreground">Unit Cost (Auto)</Label>
+                    <div className="flex items-center h-10 px-3 rounded-md border border-primary/30 bg-muted text-muted-foreground">
                       {formatCurrency(calculateUnitCost())}
                     </div>
                   </div>
@@ -296,7 +296,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
 
                 <div className="grid grid-cols-1 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="qtyInStock" className="text-sm text-foreground/85">
+                    <Label htmlFor="qtyInStock" className="text-sm text-muted-foreground">
                       Qty in Stock
                     </Label>
                     <Input
@@ -334,9 +334,9 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="text-center py-8 text-foreground/60">Loading batches...</div>
+          <div className="text-center py-8 text-muted-foreground">Loading batches...</div>
         ) : batches.length === 0 ? (
-          <div className="text-center py-8 text-foreground/60">
+          <div className="text-center py-8 text-muted-foreground">
             No inventory batches yet. Add your first batch to get started.
           </div>
         ) : (
@@ -358,7 +358,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-2">
-                        <h3 className="font-medium text-foreground/85">{batch.batchName}</h3>
+                        <h3 className="font-medium text-muted-foreground">{batch.batchName}</h3>
                         <Badge variant="secondary" className="text-xs">
                           {batch.productName}
                         </Badge>
@@ -366,26 +366,26 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                       
                       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
                         <div>
-                          <span className="text-foreground/60">Total Cost:</span>
-                          <div className="font-medium text-foreground/85">
+                          <span className="text-muted-foreground">Total Cost:</span>
+                          <div className="font-medium text-muted-foreground">
                             {formatCurrency(parseFloat(batch.totalPricePaid))}
                           </div>
                         </div>
                         <div>
-                          <span className="text-foreground/60">Unit Cost:</span>
-                          <div className="font-medium text-foreground/85">
+                          <span className="text-muted-foreground">Unit Cost:</span>
+                          <div className="font-medium text-muted-foreground">
                             {formatCurrency(parseFloat(batch.unitCost))}
                           </div>
                         </div>
                         <div>
-                          <span className="text-foreground/60">Projected Sale Price:</span>
-                          <div className="font-medium text-foreground/85">
+                          <span className="text-muted-foreground">Projected Sale Price:</span>
+                          <div className="font-medium text-muted-foreground">
                             {formatCurrency(parseFloat(batch.projectedSaleCostPerUnit || "0"))}
                           </div>
                         </div>
                         <div>
-                          <span className="text-foreground/60">Actual Sale Price:</span>
-                          <div className="font-medium text-foreground/85">
+                          <span className="text-muted-foreground">Actual Sale Price:</span>
+                          <div className="font-medium text-muted-foreground">
                             {formatCurrency(parseFloat(batch.actualSaleCostPerUnit || "0"))}
                           </div>
                         </div>
@@ -393,25 +393,25 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
 
                       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm mt-2">
                         <div>
-                          <span className="text-foreground/60">In Stock:</span>
-                          <div className="font-medium text-foreground/85">
+                          <span className="text-muted-foreground">In Stock:</span>
+                          <div className="font-medium text-muted-foreground">
                             {batch.qtyInStock} / {batch.numberOfUnits}
                           </div>
                         </div>
                         <div>
-                          <span className="text-foreground/60">Sold:</span>
-                          <div className="font-medium text-foreground/85">
+                          <span className="text-muted-foreground">Sold:</span>
+                          <div className="font-medium text-muted-foreground">
                             {batch.qtySold || 0}
                           </div>
                         </div>
                         <div>
-                          <span className="text-foreground/60">Break Even (Units):</span>
-                          <div className="font-medium text-foreground/85">
+                          <span className="text-muted-foreground">Break Even (Units):</span>
+                          <div className="font-medium text-muted-foreground">
                             {breakEven.unitsToBreakEven > 0 ? `${breakEven.unitsToBreakEven} units` : "Set projected price"}
                           </div>
                         </div>
                         <div>
-                          <span className="text-foreground/60">Projected Profit/Unit:</span>
+                          <span className="text-muted-foreground">Projected Profit/Unit:</span>
                           <div className={`font-medium ${breakEven.projectedProfitPerUnit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                             {formatCurrency(breakEven.projectedProfitPerUnit)}
                           </div>
@@ -420,7 +420,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
 
                       <Separator className="my-3" />
                       
-                      <div className="flex items-center gap-4 text-xs text-foreground/60">
+                      <div className="flex items-center gap-4 text-xs text-muted-foreground">
                         <div className="flex items-center gap-1">
                           <Calculator className="h-3 w-3" />
                           Break-even: {breakEven.unitsToBreakEven > 0 ? `${breakEven.unitsToBreakEven} units` : "Set projected price"} 

--- a/src/components/sales-tracker.tsx
+++ b/src/components/sales-tracker.tsx
@@ -225,8 +225,8 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
     return (
       <Card className="border-2 border-primary/20">
         <CardContent className="pt-6">
-          <div className="text-center py-8 text-foreground/60">
-            <ShoppingCart className="h-12 w-12 mx-auto mb-3 text-foreground/40" />
+          <div className="text-center py-8 text-muted-foreground">
+            <ShoppingCart className="h-12 w-12 mx-auto mb-3 text-muted-foreground" />
             <p>Select an inventory batch to track sales</p>
           </div>
         </CardContent>
@@ -240,7 +240,7 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <ShoppingCart className="h-5 w-5 text-primary" />
-            <CardTitle className="text-foreground/85">
+            <CardTitle className="text-muted-foreground">
               Sales Tracker - {selectedBatch.batchName}
             </CardTitle>
           </div>
@@ -256,12 +256,12 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
             </DialogTrigger>
             <DialogContent className="bg-background border-2 border-primary/20">
               <DialogHeader>
-                <DialogTitle className="text-foreground/85">Record New Sale</DialogTitle>
+                <DialogTitle className="text-muted-foreground">Record New Sale</DialogTitle>
               </DialogHeader>
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="qty" className="text-sm text-foreground/85">
+                    <Label htmlFor="qty" className="text-sm text-muted-foreground">
                       Quantity Sold
                     </Label>
                     <Input
@@ -282,12 +282,12 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                       className="bg-input border-primary/30 text-foreground"
                       required
                     />
-                    <div className="text-xs text-foreground/60">
+                    <div className="text-xs text-muted-foreground">
                       Available: {selectedBatch.qtyInStock} units
                     </div>
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="totalPrice" className="text-sm text-foreground/85">
+                    <Label htmlFor="totalPrice" className="text-sm text-muted-foreground">
                       Total Price
                     </Label>
                     <CurrencyInput
@@ -310,14 +310,14 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
 
                 <div className="grid grid-cols-1 gap-4">
                   <div className="space-y-2">
-                    <Label className="text-sm text-foreground/85">Price Per Unit (Auto-calculated)</Label>
-                    <div className="flex items-center h-10 px-3 rounded-md border border-primary/30 bg-muted text-foreground/85">
+                    <Label className="text-sm text-muted-foreground">Price Per Unit (Auto-calculated)</Label>
+                    <div className="flex items-center h-10 px-3 rounded-md border border-primary/30 bg-muted text-muted-foreground">
                       {formData.qty && formData.totalPrice ? 
                         formatCurrency(parseFloat(formData.totalPrice) / parseInt(formData.qty)) : 
                         formatCurrency(0)
                       }
                     </div>
-                    <div className="text-xs text-foreground/60">
+                    <div className="text-xs text-muted-foreground">
                       Projected: {formatCurrency(parseFloat(selectedBatch.projectedSaleCostPerUnit || "0"))}
                     </div>
                   </div>
@@ -325,7 +325,7 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                 
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
-                    <Label htmlFor="amountPaid" className="text-sm text-foreground/85">
+                    <Label htmlFor="amountPaid" className="text-sm text-muted-foreground">
                       Amount Paid
                     </Label>
                     <CurrencyInput
@@ -337,15 +337,15 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label className="text-sm text-foreground/85">Balance Owing (Auto)</Label>
-                    <div className="flex items-center h-10 px-3 rounded-md border border-primary/30 bg-muted text-foreground/85">
+                    <Label className="text-sm text-muted-foreground">Balance Owing (Auto)</Label>
+                    <div className="flex items-center h-10 px-3 rounded-md border border-primary/30 bg-muted text-muted-foreground">
                       {formatCurrency(calculateBalance())}
                     </div>
                   </div>
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="notes" className="text-sm text-foreground/85">
+                  <Label htmlFor="notes" className="text-sm text-muted-foreground">
                     Notes (Optional)
                   </Label>
                   <Textarea
@@ -383,25 +383,25 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
         {/* Sales Summary */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6 p-4 rounded-lg bg-primary/5 border border-primary/20">
           <div className="text-center">
-            <div className="text-sm text-foreground/60">Total Revenue</div>
-            <div className="text-lg font-semibold text-foreground/85">
+            <div className="text-sm text-muted-foreground">Total Revenue</div>
+            <div className="text-lg font-semibold text-muted-foreground">
               {formatCurrency(summary.totalRevenue)}
             </div>
           </div>
           <div className="text-center">
-            <div className="text-sm text-foreground/60">Units Sold</div>
-            <div className="text-lg font-semibold text-foreground/85">
+            <div className="text-sm text-muted-foreground">Units Sold</div>
+            <div className="text-lg font-semibold text-muted-foreground">
               {summary.totalSold}
             </div>
           </div>
           <div className="text-center">
-            <div className="text-sm text-foreground/60">Profit</div>
+            <div className="text-sm text-muted-foreground">Profit</div>
             <div className={`text-lg font-semibold ${summary.profit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
               {formatCurrency(summary.profit)}
             </div>
           </div>
           <div className="text-center">
-            <div className="text-sm text-foreground/60">Margin</div>
+            <div className="text-sm text-muted-foreground">Margin</div>
             <div className={`text-lg font-semibold ${summary.profitMargin >= 0 ? 'text-green-600' : 'text-red-600'}`}>
               {summary.profitMargin.toFixed(1)}%
             </div>
@@ -410,9 +410,9 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
 
         {/* Sales Records */}
         {isLoading ? (
-          <div className="text-center py-8 text-foreground/60">Loading sales records...</div>
+          <div className="text-center py-8 text-muted-foreground">Loading sales records...</div>
         ) : salesRecords.length === 0 ? (
-          <div className="text-center py-8 text-foreground/60">
+          <div className="text-center py-8 text-muted-foreground">
             No sales recorded yet. Add your first sale to get started.
           </div>
         ) : (
@@ -428,33 +428,33 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                       <Badge variant="secondary" className="text-xs">
                         {record.qty} units
                       </Badge>
-                      <span className="text-xs text-foreground/60">
+                      <span className="text-xs text-muted-foreground">
                         {new Date(record.createdAt!).toLocaleDateString()}
                       </span>
                     </div>
                     
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
                       <div>
-                        <span className="text-foreground/60">Total Price:</span>
-                        <div className="font-medium text-foreground/85">
+                        <span className="text-muted-foreground">Total Price:</span>
+                        <div className="font-medium text-muted-foreground">
                           {formatCurrency(parseFloat(record.totalPrice))}
                         </div>
                       </div>
                       <div>
-                        <span className="text-foreground/60">Amount Paid:</span>
-                        <div className="font-medium text-foreground/85">
+                        <span className="text-muted-foreground">Amount Paid:</span>
+                        <div className="font-medium text-muted-foreground">
                           {formatCurrency(parseFloat(record.amountPaid))}
                         </div>
                       </div>
                       <div>
-                        <span className="text-foreground/60">Balance Owing:</span>
+                        <span className="text-muted-foreground">Balance Owing:</span>
                         <div className={`font-medium ${parseFloat(record.balanceOwing) > 0 ? 'text-red-600' : 'text-green-600'}`}>
                           {formatCurrency(parseFloat(record.balanceOwing))}
                         </div>
                       </div>
                       <div>
-                        <span className="text-foreground/60">Unit Price:</span>
-                        <div className="font-medium text-foreground/85">
+                        <span className="text-muted-foreground">Unit Price:</span>
+                        <div className="font-medium text-muted-foreground">
                           {formatCurrency(parseFloat(record.totalPrice) / record.qty)}
                         </div>
                       </div>
@@ -464,8 +464,8 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                       <>
                         <Separator className="my-3" />
                         <div className="flex items-start gap-2 text-sm">
-                          <FileText className="h-4 w-4 text-foreground/40 mt-0.5" />
-                          <span className="text-foreground/70">{record.notes}</span>
+                          <FileText className="h-4 w-4 text-muted-foreground mt-0.5" />
+                          <span className="text-muted-foreground">{record.notes}</span>
                         </div>
                       </>
                     )}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
     toast-close=""

--- a/src/pages/inventory-page.tsx
+++ b/src/pages/inventory-page.tsx
@@ -40,7 +40,7 @@ export default function InventoryPage() {
                   className="h-8 w-auto object-contain"
                 />
                 <div className="hidden sm:block">
-                  <h1 className="text-lg font-semibold text-foreground/85">
+                  <h1 className="text-lg font-semibold text-muted-foreground">
                     Inventory & Sales Tracker
                   </h1>
                 </div>
@@ -62,8 +62,8 @@ export default function InventoryPage() {
                     <Package className="h-5 w-5 text-primary" />
                   </div>
                   <div>
-                    <p className="text-sm text-foreground/60">Inventory Management</p>
-                    <p className="text-lg font-semibold text-foreground/85">Track Batches</p>
+                    <p className="text-sm text-muted-foreground">Inventory Management</p>
+                    <p className="text-lg font-semibold text-muted-foreground">Track Batches</p>
                   </div>
                 </div>
               </CardContent>
@@ -76,8 +76,8 @@ export default function InventoryPage() {
                     <TrendingUp className="h-5 w-5 text-green-600" />
                   </div>
                   <div>
-                    <p className="text-sm text-foreground/60">Sales Tracking</p>
-                    <p className="text-lg font-semibold text-foreground/85">Record Sales</p>
+                    <p className="text-sm text-muted-foreground">Sales Tracking</p>
+                    <p className="text-lg font-semibold text-muted-foreground">Record Sales</p>
                   </div>
                 </div>
               </CardContent>
@@ -90,8 +90,8 @@ export default function InventoryPage() {
                     <TrendingUp className="h-5 w-5 text-blue-600" />
                   </div>
                   <div>
-                    <p className="text-sm text-foreground/60">Profit Analysis</p>
-                    <p className="text-lg font-semibold text-foreground/85">Break-even</p>
+                    <p className="text-sm text-muted-foreground">Profit Analysis</p>
+                    <p className="text-lg font-semibold text-muted-foreground">Break-even</p>
                   </div>
                 </div>
               </CardContent>
@@ -117,9 +117,9 @@ export default function InventoryPage() {
           {/* Instructions */}
           <Card className="border-2 border-primary/20 bg-primary/5">
             <CardHeader>
-              <CardTitle className="text-foreground/85 text-base">How to Use</CardTitle>
+              <CardTitle className="text-muted-foreground text-base">How to Use</CardTitle>
             </CardHeader>
-            <CardContent className="text-sm text-foreground/70 space-y-2">
+            <CardContent className="text-sm text-muted-foreground space-y-2">
               <p><strong>1. Create Inventory Batches:</strong> Add batches of products with total cost, units, and initial stock.</p>
               <p><strong>2. Track Sales:</strong> Select a batch and record individual sales with quantities, prices, and payment details.</p>
               <p><strong>3. Monitor Profitability:</strong> View real-time profit margins, break-even analysis, and outstanding balances.</p>

--- a/src/pages/login-page-netlify.tsx
+++ b/src/pages/login-page-netlify.tsx
@@ -53,10 +53,10 @@ export default function LoginPage() {
               <span className="text-white font-bold text-lg">F</span>
             </div>
           </div>
-          <CardTitle className="text-2xl text-foreground/85">
+          <CardTitle className="text-2xl text-muted-foreground">
             Welcome to FINTRAK
           </CardTitle>
-          <p className="text-sm text-foreground/60">
+          <p className="text-sm text-muted-foreground">
             Sign in to access your financial calculator
           </p>
         </CardHeader>
@@ -69,11 +69,11 @@ export default function LoginPage() {
             )}
             
             <div className="space-y-2">
-              <Label htmlFor="username" className="text-sm text-foreground/85">
+              <Label htmlFor="username" className="text-sm text-muted-foreground">
                 Username
               </Label>
               <div className="relative">
-                <User className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-foreground/40" />
+                <User className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   id="username"
                   type="text"
@@ -87,11 +87,11 @@ export default function LoginPage() {
             </div>
             
             <div className="space-y-2">
-              <Label htmlFor="password" className="text-sm text-foreground/85">
+              <Label htmlFor="password" className="text-sm text-muted-foreground">
                 Password
               </Label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-foreground/40" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   id="password"
                   type="password"
@@ -113,7 +113,7 @@ export default function LoginPage() {
             </Button>
           </form>
           
-          <div className="mt-6 text-center text-xs text-foreground/60">
+          <div className="mt-6 text-center text-xs text-muted-foreground">
             <p>Demo credentials: admin / fintrak2025</p>
           </div>
         </CardContent>

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -65,7 +65,7 @@ export default function LoginPage() {
               )}
               
               <div className="space-y-2">
-                <Label htmlFor="username" className="text-sm font-medium text-foreground/85">
+                <Label htmlFor="username" className="text-sm font-medium text-muted-foreground">
                   Username
                 </Label>
                 <Input
@@ -80,7 +80,7 @@ export default function LoginPage() {
               </div>
               
               <div className="space-y-2">
-                <Label htmlFor="password" className="text-sm font-medium text-foreground/85">
+                <Label htmlFor="password" className="text-sm font-medium text-muted-foreground">
                   Password
                 </Label>
                 <div className="relative">


### PR DESCRIPTION
## Summary
- replace `text-foreground/<opacity>` with `text-muted-foreground` for consistent secondary text
- rely on existing `muted-foreground` theme token for unified contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba9e90258832dbf0afe0afc493dae