### PR TITLE
feat: add semantic success and destructive color tokens

### DIFF
--- a/src/components/export-buttons.tsx
+++ b/src/components/export-buttons.tsx
@@ -40,11 +40,11 @@ export function ExportButtons({ data }: ExportButtonsProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="bg-background border border-border shadow-lg">
         <DropdownMenuItem onClick={handleExcelExport} className="text-foreground hover:bg-accent hover:text-accent-foreground">
-          <FileSpreadsheet className="h-4 w-4 mr-2 text-green-600" />
+          <FileSpreadsheet className="h-4 w-4 mr-2 text-success" />
           Export to Excel (.xlsx)
         </DropdownMenuItem>
         <DropdownMenuItem onClick={handlePDFExport} className="text-foreground hover:bg-accent hover:text-accent-foreground">
-          <FileText className="h-4 w-4 mr-2 text-red-600" />
+          <FileText className="h-4 w-4 mr-2 text-destructive" />
           Export to PDF (.pdf)
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/components/inventory-tracker.tsx
+++ b/src/components/inventory-tracker.tsx
@@ -412,7 +412,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                         </div>
                         <div>
                           <span className="text-foreground/60">Projected Profit/Unit:</span>
-                          <div className={`font-medium ${breakEven.projectedProfitPerUnit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                          <div className={`font-medium ${breakEven.projectedProfitPerUnit >= 0 ? 'text-success' : 'text-destructive'}`}>
                             {formatCurrency(breakEven.projectedProfitPerUnit)}
                           </div>
                         </div>
@@ -456,7 +456,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                             deleteBatchMutation.mutate(batch.id);
                           }
                         }}
-                        className="border-red-300 text-red-600 hover:bg-red-50 h-8 px-2"
+                        className="border-red-300 text-destructive hover:bg-red-50 h-8 px-2"
                       >
                         <Trash2 className="h-3 w-3" />
                       </Button>

--- a/src/components/sales-tracker.tsx
+++ b/src/components/sales-tracker.tsx
@@ -396,13 +396,13 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
           </div>
           <div className="text-center">
             <div className="text-sm text-foreground/60">Profit</div>
-            <div className={`text-lg font-semibold ${summary.profit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            <div className={`text-lg font-semibold ${summary.profit >= 0 ? 'text-success' : 'text-destructive'}`}>
               {formatCurrency(summary.profit)}
             </div>
           </div>
           <div className="text-center">
             <div className="text-sm text-foreground/60">Margin</div>
-            <div className={`text-lg font-semibold ${summary.profitMargin >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            <div className={`text-lg font-semibold ${summary.profitMargin >= 0 ? 'text-success' : 'text-destructive'}`}>
               {summary.profitMargin.toFixed(1)}%
             </div>
           </div>
@@ -448,7 +448,7 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                       </div>
                       <div>
                         <span className="text-foreground/60">Balance Owing:</span>
-                        <div className={`font-medium ${parseFloat(record.balanceOwing) > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                        <div className={`font-medium ${parseFloat(record.balanceOwing) > 0 ? 'text-destructive' : 'text-success'}`}>
                           {formatCurrency(parseFloat(record.balanceOwing))}
                         </div>
                       </div>
@@ -479,7 +479,7 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                         deleteSaleMutation.mutate(record.id);
                       }
                     }}
-                    className="border-red-300 text-red-600 hover:bg-red-50 h-8 px-2 ml-4"
+                    className="border-red-300 text-destructive hover:bg-red-50 h-8 px-2 ml-4"
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,8 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142.1 76.2% 36.3%;
+  --success-foreground: 210 40% 98%;
   --border: 217.2 91.2% 59.8%;
   --card-border: 217.2 91.2% 59.8%;
   --input: 217.2 32.6% 17.5%;

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -18,6 +18,8 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142.1 76.2% 36.3%;
+  --success-foreground: 210 40% 98%;
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
   --ring: 212.7 26.8% 83.9%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,6 +41,10 @@ export default {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
## Summary
- define `success` color tokens and expose `text-success` utility
- replace hard-coded green/red text classes in trackers and export buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba9de2a98832d8f3ec04b0659a8a5