### PR TITLE
refactor: use destructive variant for delete buttons

### DIFF
--- a/src/components/bank-accounts.tsx
+++ b/src/components/bank-accounts.tsx
@@ -117,10 +117,10 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
                 className="w-28 sm:w-32 text-base"
               />
               <Button
-                variant="ghost"
+                variant="destructive"
                 size="sm"
                 onClick={() => removeBankAccountRow(row.id)}
-                className="text-destructive hover:text-destructive/80 p-2"
+                className="p-2"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/src/components/sales-tracker.tsx
+++ b/src/components/sales-tracker.tsx
@@ -473,13 +473,13 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                   
                   <Button
                     size="sm"
-                    variant="outline"
+                    variant="destructive"
                     onClick={() => {
                       if (confirm("Delete this sales record?")) {
                         deleteSaleMutation.mutate(record.id);
                       }
                     }}
-                    className="border-red-300 text-red-600 hover:bg-red-50 h-8 px-2 ml-4"
+                    className="h-8 px-2 ml-4"
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>

--- a/src/components/week-calculator.tsx
+++ b/src/components/week-calculator.tsx
@@ -182,10 +182,9 @@ export function WeekCalculator({
           </div>
           {canRemove && onRemove && (
             <Button
-              variant="ghost" 
+              variant="destructive"
               size="sm"
               onClick={onRemove}
-              className="text-destructive hover:text-destructive/80 hover:bg-destructive/10"
             >
               <X className="h-4 w-4" />
             </Button>
@@ -251,10 +250,10 @@ export function WeekCalculator({
                   className="w-28 sm:w-32 text-base bg-input text-foreground border-border"
                 />
                 <Button
-                  variant="ghost"
+                  variant="destructive"
                   size="sm"
                   onClick={() => removeIncomeRow(row.id)}
-                  className="text-destructive hover:text-destructive/80 p-2"
+                  className="p-2"
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
@@ -297,10 +296,10 @@ export function WeekCalculator({
                   className="w-28 sm:w-32 text-base bg-input text-foreground border-border"
                 />
                 <Button
-                  variant="ghost"
+                  variant="destructive"
                   size="sm"
                   onClick={() => removeExpenseRow(row.id)}
-                  className="text-destructive hover:text-destructive/80 p-2"
+                  className="p-2"
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>


### PR DESCRIPTION
## Summary
- use `destructive` button variant for bank account deletion
- apply `destructive` variant for week row and income/expense removals
- style sales record deletion buttons with `destructive` variant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abab0dc684832daa3f59f3c8afb3fa