### PR TITLE
feat: add semantic color tokens and replace raw classes

### DIFF
--- a/src/components/inventory-tracker.tsx
+++ b/src/components/inventory-tracker.tsx
@@ -412,7 +412,7 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                         </div>
                         <div>
                           <span className="text-muted-foreground">Projected Profit/Unit:</span>
-                          <div className={`font-medium ${breakEven.projectedProfitPerUnit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                          <div className={`font-medium ${breakEven.projectedProfitPerUnit >= 0 ? 'text-success' : 'text-destructive'}`}>
                             {formatCurrency(breakEven.projectedProfitPerUnit)}
                           </div>
                         </div>
@@ -449,14 +449,14 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                       </Button>
                       <Button
                         size="sm"
-                        variant="outline"
+                        variant="destructive"
                         onClick={(e) => {
                           e.stopPropagation();
                           if (confirm("Delete this batch?")) {
                             deleteBatchMutation.mutate(batch.id);
                           }
                         }}
-                        className="border-red-300 text-red-600 hover:bg-red-50 h-8 px-2"
+                        className="h-8 px-2"
                       >
                         <Trash2 className="h-3 w-3" />
                       </Button>

--- a/src/components/quick-add-shortcuts.tsx
+++ b/src/components/quick-add-shortcuts.tsx
@@ -60,10 +60,10 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
               {INCOME_SHORTCUTS.map((shortcut, index) => (
                 <Button
                   key={`${shortcut.label}-${shortcut.amount}-${index}`}
-                  variant="income"
+                  variant="outline"
                   size="sm"
                   onClick={() => onAddIncome(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2"
+                  className="text-xs h-7 px-2 bg-success/10 text-success border-success/20 hover:bg-success/20"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">
@@ -81,10 +81,10 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
               {EXPENSE_SHORTCUTS.map((shortcut, index) => (
                 <Button
                   key={`${shortcut.label}-${shortcut.amount}-${index}`}
-                  variant="expense"
+                  variant="outline"
                   size="sm"
                   onClick={() => onAddExpense(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2"
+                  className="text-xs h-7 px-2 bg-destructive/10 text-destructive border-destructive/20 hover:bg-destructive/20"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">

--- a/src/components/sales-tracker.tsx
+++ b/src/components/sales-tracker.tsx
@@ -396,13 +396,13 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
           </div>
           <div className="text-center">
             <div className="text-sm text-muted-foreground">Profit</div>
-            <div className={`text-lg font-semibold ${summary.profit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            <div className={`text-lg font-semibold ${summary.profit >= 0 ? 'text-success' : 'text-destructive'}`}>
               {formatCurrency(summary.profit)}
             </div>
           </div>
           <div className="text-center">
             <div className="text-sm text-muted-foreground">Margin</div>
-            <div className={`text-lg font-semibold ${summary.profitMargin >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            <div className={`text-lg font-semibold ${summary.profitMargin >= 0 ? 'text-success' : 'text-destructive'}`}>
               {summary.profitMargin.toFixed(1)}%
             </div>
           </div>
@@ -448,7 +448,7 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                       </div>
                       <div>
                         <span className="text-muted-foreground">Balance Owing:</span>
-                        <div className={`font-medium ${parseFloat(record.balanceOwing) > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                        <div className={`font-medium ${parseFloat(record.balanceOwing) > 0 ? 'text-destructive' : 'text-success'}`}>
                           {formatCurrency(parseFloat(record.balanceOwing))}
                         </div>
                       </div>
@@ -473,13 +473,13 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                   
                   <Button
                     size="sm"
-                    variant="outline"
+                    variant="destructive"
                     onClick={() => {
                       if (confirm("Delete this sales record?")) {
                         deleteSaleMutation.mutate(record.id);
                       }
                     }}
-                    className="border-red-300 text-red-600 hover:bg-red-50 h-8 px-2 ml-4"
+                    className="h-8 px-2 ml-4"
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,10 +18,6 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        income:
-          "bg-green-50 hover:bg-green-100 border border-green-200 text-green-700 dark:bg-green-950/50 dark:hover:bg-green-900/50 dark:border-green-800 dark:text-green-300",
-        expense:
-          "bg-red-50 hover:bg-red-100 border border-red-200 text-red-700 dark:bg-red-950/50 dark:hover:bg-red-900/50 dark:border-red-800 dark:text-red-300",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/week-calculator.tsx
+++ b/src/components/week-calculator.tsx
@@ -263,7 +263,7 @@ export function WeekCalculator({
           </div>
           <div className="mt-3 text-right">
             <span className="text-sm text-muted-foreground">Total Income: </span>
-            <span className="text-sm font-semibold text-green-400">
+            <span className="text-sm font-semibold text-success">
               {formatCurrency(totalIncome)}
             </span>
           </div>
@@ -309,7 +309,7 @@ export function WeekCalculator({
           </div>
           <div className="mt-3 text-right">
             <span className="text-sm text-muted-foreground">Total Expenses: </span>
-            <span className="text-sm font-semibold text-red-400">
+            <span className="text-sm font-semibold text-destructive">
               {formatCurrency(totalExpenses)}
             </span>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,12 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 72% 35%;
+  --success-foreground: 210 40% 98%;
+  --warning: 38 92% 50%;
+  --warning-foreground: 222.2 84% 4.9%;
+  --info: 199 89% 48%;
+  --info-foreground: 210 40% 98%;
   --border: 217.2 91.2% 59.8%;
   --card-border: 217.2 91.2% 59.8%;
   --input: 217.2 32.6% 17.5%;

--- a/src/styles/dark-mode.css
+++ b/src/styles/dark-mode.css
@@ -18,6 +18,12 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --success: 142 72% 35%;
+  --success-foreground: 210 40% 98%;
+  --warning: 38 92% 50%;
+  --warning-foreground: 222.2 84% 4.9%;
+  --info: 199 89% 48%;
+  --info-foreground: 210 40% 98%;
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
   --ring: 212.7 26.8% 83.9%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,6 +41,18 @@ export default {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
## Summary
- add success, warning, and info semantic colors to Tailwind config and theme variables
- replace hardcoded green/red classes in tracker components with semantic utilities
- switch destructive actions to use Button's `destructive` variant and semantic colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abaaeec014832dbc12d0f00f3fb0cb