### PR TITLE
refactor: rely on Button variants for color

### DIFF
--- a/src/components/bank-accounts.tsx
+++ b/src/components/bank-accounts.tsx
@@ -117,10 +117,10 @@ export function BankAccounts({ bankAccountRows: initialBankAccountRows, onUpdate
                 className="w-28 sm:w-32 text-base"
               />
               <Button
-                variant="ghost"
+                variant="destructive"
                 size="sm"
                 onClick={() => removeBankAccountRow(row.id)}
-                className="text-destructive hover:text-destructive/80 p-2"
+                className="p-2"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/src/components/export-buttons.tsx
+++ b/src/components/export-buttons.tsx
@@ -29,10 +29,9 @@ export function ExportButtons({ data }: ExportButtonsProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button 
-          variant="ghost" 
+        <Button
+          variant="ghost"
           size="sm"
-          className="text-muted-foreground hover:text-foreground"
         >
           <Download className="h-4 w-4 mr-1 sm:mr-2" />
           <span className="hidden sm:inline">Export</span>

--- a/src/components/inventory-tracker.tsx
+++ b/src/components/inventory-tracker.tsx
@@ -312,11 +312,10 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                 </div>
 
                 <div className="flex justify-end gap-2 pt-4">
-                  <Button 
-                    type="button" 
-                    variant="outline" 
+                  <Button
+                    type="button"
+                    variant="outline"
                     onClick={() => setIsAddDialogOpen(false)}
-                    className="border-primary/30"
                   >
                     Cancel
                   </Button>
@@ -443,20 +442,20 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
                           e.stopPropagation();
                           handleEdit(batch);
                         }}
-                        className="border-primary/30 h-8 px-2"
+                        className="h-8 px-2"
                       >
                         <Edit2 className="h-3 w-3" />
                       </Button>
                       <Button
                         size="sm"
-                        variant="outline"
+                        variant="destructive"
                         onClick={(e) => {
                           e.stopPropagation();
                           if (confirm("Delete this batch?")) {
                             deleteBatchMutation.mutate(batch.id);
                           }
                         }}
-                        className="border-red-300 text-red-600 hover:bg-red-50 h-8 px-2"
+                        className="h-8 px-2"
                       >
                         <Trash2 className="h-3 w-3" />
                       </Button>

--- a/src/components/quick-add-shortcuts.tsx
+++ b/src/components/quick-add-shortcuts.tsx
@@ -36,9 +36,10 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
   return (
     <div className="bg-primary/5 dark:bg-primary/10 rounded-lg border border-primary/20 dark:border-primary/30">
       {/* Collapsible Header */}
-      <button
+      <Button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-3 text-left hover:bg-primary/10 dark:hover:bg-primary/20 rounded-lg transition-colors touch-manipulation [-webkit-tap-highlight-color:transparent]"
+        variant="ghost"
+        className="w-full flex items-center justify-between p-3 touch-manipulation"
       >
         <h3 className="text-sm font-medium text-primary dark:text-primary">
           Quick Add - Week {weekNumber}
@@ -48,7 +49,7 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
         ) : (
           <ChevronDown className="h-4 w-4 text-primary" />
         )}
-      </button>
+      </Button>
 
       {/* Collapsible Content */}
       {isExpanded && (
@@ -63,7 +64,7 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
                   variant="income"
                   size="sm"
                   onClick={() => onAddIncome(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2"
+                  className="h-7 px-2"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">
@@ -84,7 +85,7 @@ export function QuickAddShortcuts({ onAddIncome, onAddExpense, weekNumber }: Qui
                   variant="expense"
                   size="sm"
                   onClick={() => onAddExpense(shortcut.label, shortcut.amount)}
-                  className="text-xs h-7 px-2"
+                  className="h-7 px-2"
                 >
                   <Plus className="h-3 w-3 mr-1 flex-shrink-0" />
                   <span className="truncate">

--- a/src/components/sales-tracker.tsx
+++ b/src/components/sales-tracker.tsx
@@ -359,11 +359,10 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                 </div>
 
                 <div className="flex justify-end gap-2 pt-4">
-                  <Button 
-                    type="button" 
-                    variant="outline" 
+                  <Button
+                    type="button"
+                    variant="outline"
                     onClick={() => setIsAddDialogOpen(false)}
-                    className="border-primary/30"
                   >
                     Cancel
                   </Button>
@@ -473,13 +472,13 @@ export function SalesTracker({ selectedBatch }: SalesTrackerProps) {
                   
                   <Button
                     size="sm"
-                    variant="outline"
+                    variant="destructive"
                     onClick={() => {
                       if (confirm("Delete this sales record?")) {
                         deleteSaleMutation.mutate(record.id);
                       }
                     }}
-                    className="border-red-300 text-red-600 hover:bg-red-50 h-8 px-2 ml-4"
+                    className="h-8 px-2 ml-4"
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>

--- a/src/components/week-calculator.tsx
+++ b/src/components/week-calculator.tsx
@@ -182,10 +182,9 @@ export function WeekCalculator({
           </div>
           {canRemove && onRemove && (
             <Button
-              variant="ghost" 
+              variant="destructive"
               size="sm"
               onClick={onRemove}
-              className="text-destructive hover:text-destructive/80 hover:bg-destructive/10"
             >
               <X className="h-4 w-4" />
             </Button>
@@ -251,10 +250,10 @@ export function WeekCalculator({
                   className="w-28 sm:w-32 text-base bg-input text-foreground border-border"
                 />
                 <Button
-                  variant="ghost"
+                  variant="destructive"
                   size="sm"
                   onClick={() => removeIncomeRow(row.id)}
-                  className="text-destructive hover:text-destructive/80 p-2"
+                  className="p-2"
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
@@ -297,10 +296,10 @@ export function WeekCalculator({
                   className="w-28 sm:w-32 text-base bg-input text-foreground border-border"
                 />
                 <Button
-                  variant="ghost"
+                  variant="destructive"
                   size="sm"
                   onClick={() => removeExpenseRow(row.id)}
-                  className="text-destructive hover:text-destructive/80 p-2"
+                  className="p-2"
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -390,7 +390,6 @@ export default function Home() {
                 variant="outline"
                 size="sm"
                 onClick={() => window.location.href = "/inventory"}
-                className="border-primary/30 hover:bg-primary/10"
               >
                 <Package className="h-4 w-4 mr-1" />
                 Inventory
@@ -407,20 +406,18 @@ export default function Home() {
                 week2Balance: week1Balance + week2IncomeRows.reduce((sum, row) => sum + row.amount, 0) - week2ExpenseRows.reduce((sum, row) => sum + row.amount, 0),
                 totalBankBalance: bankAccountRows.reduce((sum, row) => sum + row.amount, 0)
               }} />
-              <Button 
-                variant="ghost"
+              <Button
+                variant="destructive"
                 size="sm"
                 onClick={() => setShowClearDialog(true)}
-                className="text-destructive hover:text-destructive/80"
               >
                 <Trash2 className="h-4 w-4 mr-2" />
                 Clear All
               </Button>
-              <Button 
+              <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => window.location.href = '/login'}
-                className="text-muted-foreground hover:text-foreground"
               >
                 Sign Out
               </Button>
@@ -432,7 +429,6 @@ export default function Home() {
                 variant="outline"
                 size="sm"
                 onClick={() => window.location.href = "/inventory"}
-                className="border-primary/30 hover:bg-primary/10"
               >
                 <Package className="h-4 w-4" />
               </Button>
@@ -447,19 +443,19 @@ export default function Home() {
                 week2Balance: week1Balance + week2IncomeRows.reduce((sum, row) => sum + row.amount, 0) - week2ExpenseRows.reduce((sum, row) => sum + row.amount, 0),
                 totalBankBalance: bankAccountRows.reduce((sum, row) => sum + row.amount, 0)
               }} />
-              <Button 
-                variant="ghost"
+              <Button
+                variant="destructive"
                 size="sm"
                 onClick={() => setShowClearDialog(true)}
-                className="text-destructive hover:text-destructive/80 px-2"
+                className="px-2"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>
-              <Button 
+              <Button
                 variant="ghost"
                 size="sm"
                 onClick={() => window.location.href = '/login'}
-                className="text-muted-foreground hover:text-foreground px-2"
+                className="px-2"
               >
                 Sign Out
               </Button>
@@ -564,10 +560,10 @@ export default function Home() {
           
           {/* Add Week Button */}
           <div className="lg:col-span-2 flex justify-center">
-            <Button 
+            <Button
               onClick={addAdditionalWeek}
               variant="outline"
-              className="w-full max-w-md border-dashed border-2 border-primary/30 hover:border-primary/50 text-primary hover:text-primary/80"
+              className="w-full max-w-md"
             >
               + Add Week {3 + additionalWeeks.length}
             </Button>

--- a/src/pages/inventory-page.tsx
+++ b/src/pages/inventory-page.tsx
@@ -27,7 +27,6 @@ export default function InventoryPage() {
                 variant="outline"
                 size="sm"
                 onClick={() => setLocation("/")}
-                className="border-primary/30"
               >
                 <ArrowLeft className="h-4 w-4 mr-1" />
                 Back to Financial Calculator

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -61,7 +61,6 @@ export default function Landing() {
           <Button
             onClick={() => window.location.href = '/api/login'}
             size="lg"
-            className="px-8 py-3 text-lg"
           >
             Get Started - Sign In
           </Button>

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -97,7 +97,7 @@ export default function LoginPage() {
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className="absolute right-0 top-0 h-full px-3 hover:bg-transparent"
+                    className="absolute right-0 top-0 h-full px-3"
                     onClick={() => setShowPassword(!showPassword)}
                     disabled={loginMutation.isPending}
                   >


### PR DESCRIPTION
## Summary
- use built-in Button variants instead of manual color classes
- keep layout/spacing classes only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abaadbbc34832db942a665a3b33490