### PR TITLE
Add dark mode overrides for all theme variations

### DIFF
--- a/src/__tests__/theme-variations.test.ts
+++ b/src/__tests__/theme-variations.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const themes = ["blue", "pink", "green", "orange", "red"] as const;
+
+describe("theme variations", () => {
+  it("defines dark mode overrides for each theme", () => {
+    const cssPath = path.resolve(__dirname, "../index.css");
+    const css = fs.readFileSync(cssPath, "utf8");
+
+    for (const theme of themes) {
+      const pattern = new RegExp(
+        `body\\.dark\\[data-theme="${theme}"\\],\\s*\\.dark body\\[data-theme="${theme}"\\]`,
+      );
+      expect(pattern.test(css)).toBe(true);
+    }
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -94,6 +94,30 @@ body.dark[data-theme="blue"],
   --primary-foreground: 222.2 84% 4.9%;
 }
 
+body.dark[data-theme="pink"],
+.dark body[data-theme="pink"] {
+  --primary: 343 100% 59%;
+  --primary-foreground: 222.2 84% 4.9%;
+}
+
+body.dark[data-theme="green"],
+.dark body[data-theme="green"] {
+  --primary: 133 73% 63%;
+  --primary-foreground: 222.2 84% 4.9%;
+}
+
+body.dark[data-theme="orange"],
+.dark body[data-theme="orange"] {
+  --primary: 35 100% 50%;
+  --primary-foreground: 222.2 84% 4.9%;
+}
+
+body.dark[data-theme="red"],
+.dark body[data-theme="red"] {
+  --primary: 355 100% 59%;
+  --primary-foreground: 222.2 84% 4.9%;
+}
+
 /* Enhanced contrast for mobile light mode */
 @media (max-width: 768px) {
   :not(.dark) .text-gray-500 {


### PR DESCRIPTION
## Summary
- extend dark mode styling to all color themes
- add test ensuring each theme includes dark variant selectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abc6068dcc832d9004dfd86786449a