### PR TITLE
Align border styles with selected theme

### DIFF
--- a/src/__tests__/dark-mode.test.ts
+++ b/src/__tests__/dark-mode.test.ts
@@ -8,6 +8,6 @@ describe("dark mode variables", () => {
     const css = fs.readFileSync(cssPath, "utf8");
     const match = /\.dark\s*\{([^}]+)\}/.exec(css);
     expect(match).not.toBeNull();
-    expect(match![1]).toContain("--ring: 212.7 26.8% 83.9%;");
+    expect(match![1]).toContain("--ring: var(--primary);");
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -19,10 +19,11 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
-  --border: 217.2 91.2% 59.8%;
-  --card-border: 217.2 91.2% 59.8%;
   --input: 217.2 32.6% 17.5%;
-  --ring: 217.2 91.2% 59.8%;
+  /* Match border and ring colors to the current theme */
+  --ring: var(--primary);
+  --border: var(--primary);
+  --card-border: var(--primary);
   --radius: 0.75rem;
 }
 .dark {
@@ -42,9 +43,11 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
-  --ring: 212.7 26.8% 83.9%;
+  /* Ensure dark mode borders follow the selected theme */
+  --ring: var(--primary);
+  --border: var(--primary);
+  --card-border: var(--primary);
   --chart-1: 220 70% 50%;
   --chart-2: 160 60% 45%;
   --chart-3: 30 80% 55%;


### PR DESCRIPTION
## Summary
- tie border and ring CSS variables to the active theme color
- update dark mode test expectation for new ring variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abc6170f70832db1143f2a7ef42538