### PR TITLE
refactor: move theme selector styles to css

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300..700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body data-theme="blue">
     <div id="root"></div>

--- a/src/components/theme-selector.css
+++ b/src/components/theme-selector.css
@@ -1,0 +1,24 @@
+.theme-button[data-theme="blue"] {
+  --primary: 211 100% 50%; /* #007AFF */
+  --tw-ring-color: #80bdff;
+}
+
+.theme-button[data-theme="pink"] {
+  --primary: 343 100% 59%; /* #FF2D55 */
+  --tw-ring-color: #ff96aa;
+}
+
+.theme-button[data-theme="green"] {
+  --primary: 133 73% 63%; /* #4CD964 */
+  --tw-ring-color: #a6ecb2;
+}
+
+.theme-button[data-theme="orange"] {
+  --primary: 35 100% 50%; /* #FF9500 */
+  --tw-ring-color: #ffca80;
+}
+
+.theme-button[data-theme="red"] {
+  --primary: 355 100% 59%; /* #FF3B30 */
+  --tw-ring-color: #ff9d98;
+}

--- a/src/components/theme-selector.tsx
+++ b/src/components/theme-selector.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTheme } from "@/contexts/simple-theme-context";
-import { themeColors, getRingColor, Theme } from "@/constants/theme";
+import { themeColors, Theme } from "@/constants/theme";
+import "./theme-selector.css";
 
 const themeOptions = Object.keys(themeColors) as Theme[];
 
@@ -13,25 +14,17 @@ export function ThemeSelector() {
     <div className="flex items-center space-x-2 sm:space-x-3">
       {/* Theme Color Buttons - Hidden on mobile */}
       <div className="hidden md:flex items-center space-x-2">
-        {themeOptions.map((id) => {
-          const ring = getRingColor(id);
-          return (
-            <button
-              key={id}
-              data-theme={id}
-              onClick={() => setTheme(id)}
-              style={{
-                // Provide color tokens for tailwind utility classes
-                "--primary": themeColors[id],
-                ...(theme === id ? { "--tw-ring-color": ring } : {}),
-              } as React.CSSProperties}
-              className={`w-10 h-4 rounded-full border-2 shadow-md transition-all bg-primary ${
-                theme === id ? "border-white ring-2" : "border-gray-300"
-              }`}
-              aria-label={`${id.charAt(0).toUpperCase() + id.slice(1)} theme`}
-            />
-          );
-        })}
+        {themeOptions.map((id) => (
+          <button
+            key={id}
+            data-theme={id}
+            onClick={() => setTheme(id)}
+            className={`theme-button w-10 h-4 rounded-full border-2 shadow-md transition-all bg-primary ${
+              theme === id ? "border-white ring-2" : "border-gray-300"
+            }`}
+            aria-label={`${id.charAt(0).toUpperCase() + id.slice(1)} theme`}
+          />
+        ))}
       </div>
 
       {/* Dark mode toggle removed - app is now permanently dark theme */}


### PR DESCRIPTION
## Summary
- move theme color variables into dedicated `theme-selector.css`
- use data-theme attributes and `theme-button` class instead of inline styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abd0b28c20832db75c13c38e5d1890