### PR TITLE
refactor: centralize theme variables

### DIFF
--- a/src/__tests__/dark-mode.test.ts
+++ b/src/__tests__/dark-mode.test.ts
@@ -3,11 +3,16 @@ import fs from "fs";
 import path from "path";
 
 describe("dark mode variables", () => {
-  it("includes ring color in the dark theme block", () => {
+  it("pulls ring color from the base scope", () => {
     const cssPath = path.resolve(__dirname, "../index.css");
     const css = fs.readFileSync(cssPath, "utf8");
-    const match = /\.dark\s*\{([^}]+)\}/.exec(css);
-    expect(match).not.toBeNull();
-    expect(match![1]).toContain("--ring: var(--primary);");
+
+    const rootMatch = /:root\s*\{([^}]+)\}/.exec(css);
+    expect(rootMatch).not.toBeNull();
+    expect(rootMatch![1]).toContain("--ring: var(--primary);");
+
+    const darkMatch = /\.dark\s*\{([^}]+)\}/.exec(css);
+    expect(darkMatch).not.toBeNull();
+    expect(darkMatch![1]).not.toContain("--ring");
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -26,33 +26,34 @@
   --card-border: var(--primary);
   --radius: 0.75rem;
 }
+
 .dark {
-  --background: 222.2 84% 4.9%;
   --foreground: 210 40% 98%;
   --card: 222.2 84% 4.9%;
-  --card-foreground: 210 40% 98%;
   --popover: 222.2 84% 4.9%;
-  --popover-foreground: 210 40% 98%;
   --primary: 217 91% 60%;
   --primary-foreground: 222.2 84% 4.9%;
-  --secondary: 217.2 32.6% 17.5%;
-  --secondary-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20.2% 65.1%;
-  --accent: 217.2 32.6% 17.5%;
-  --accent-foreground: 210 40% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 210 40% 98%;
-  --input: 217.2 32.6% 17.5%;
-  /* Ensure dark mode borders follow the selected theme */
-  --ring: var(--primary);
-  --border: var(--primary);
-  --card-border: var(--primary);
+  /* Dark mode specific charts */
   --chart-1: 220 70% 50%;
   --chart-2: 160 60% 45%;
   --chart-3: 30 80% 55%;
   --chart-4: 280 65% 60%;
   --chart-5: 340 75% 55%;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --popover: 222.2 84% 4.9%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 222.2 84% 4.9%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+  }
 }
 
 /* Override input styling for dark theme */


### PR DESCRIPTION
## Summary
- dedupe theme variables into `:root`
- keep only overrides in `.dark` and add `prefers-color-scheme` media query
- adjust dark-mode test for new variable placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abd270e9d0832daacb18dc60fd55bb