### PR TITLE
Use Space Grotesk as default font

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body data-theme="blue">
     <div id="root"></div>

--- a/src/components/font-tester.tsx
+++ b/src/components/font-tester.tsx
@@ -18,8 +18,8 @@ const FONT_OPTIONS = [
 ];
 
 export function FontTester() {
-  const [selectedFont, setSelectedFont] = useState("DM Sans");
-  const [appliedFont, setAppliedFont] = useState("DM Sans");
+  const [selectedFont, setSelectedFont] = useState("Space Grotesk");
+  const [appliedFont, setAppliedFont] = useState("Space Grotesk");
 
   // Load Google Fonts dynamically
   useEffect(() => {
@@ -56,9 +56,9 @@ export function FontTester() {
 
   const resetFont = () => {
     // Reset to default font
-    document.body.style.fontFamily = '';
-    setAppliedFont("DM Sans");
-    setSelectedFont("DM Sans");
+    document.body.style.fontFamily = '"Space Grotesk", sans-serif';
+    setAppliedFont("Space Grotesk");
+    setSelectedFont("Space Grotesk");
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -129,7 +129,7 @@ body.dark[data-theme="blue"],
   /* Space Grotesk font applied globally */
   body {
     @apply font-sans antialiased;
-    font-family: "Space Grotesk", var(--font-sans), sans-serif;
+    font-family: "Space Grotesk", sans-serif;
     color: hsl(var(--foreground));
     background: hsl(var(--background));
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,7 +63,7 @@ export default {
         },
       },
       fontFamily: {
-        sans: ["var(--font-sans)", "Inter", "sans-serif"],
+        sans: ["Space Grotesk", "sans-serif"],
         serif: ["var(--font-serif)", "Georgia", "serif"],
         mono: ["var(--font-mono)", "Menlo", "monospace"],
       },


### PR DESCRIPTION
## Summary
- switch Google Fonts link to Space Grotesk with explicit weights
- configure Tailwind to use Space Grotesk sans font
- default font tester component to Space Grotesk
- remove undefined fallback variable so Space Grotesk applies globally

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc5bbb7d0832d9652a6a3b75781dd