### PR TITLE
fix: correct Tailwind fontFamily config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -64,8 +64,6 @@ export default {
       },
       fontFamily: {
         sans: ["Space Grotesk", "var(--font-sans)", "sans-serif"],
-        
-        main
         serif: ["var(--font-serif)", "Georgia", "serif"],
         mono: ["var(--font-mono)", "Menlo", "monospace"],
       },


### PR DESCRIPTION
## Summary
- remove stray `main` entry from Tailwind `fontFamily`
- ensure only valid font families remain

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abe19a2a88832db41c289953a591c8