### PR TITLE
fix: use commonjs postcss config

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,8 @@
+// Use CommonJS exports so PostCSS can load the configuration without
+// requiring an ES module environment.
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}


### PR DESCRIPTION
## Summary
- Convert PostCSS configuration to CommonJS to avoid ESM default export issues
- Rename configuration to `postcss.config.cjs`

## Testing
- `npm run build` *(fails: [postcss] Unexpected token, expected "(")*

------
https://chatgpt.com/codex/tasks/task_e_68abe19adf20832da491a85aebf4fc37