### PR TITLE
Fix Tailwind configuration syntax

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -64,8 +64,6 @@ export default {
       },
       fontFamily: {
         sans: ["Space Grotesk", "var(--font-sans)", "sans-serif"],
-        
-        main
         serif: ["var(--font-serif)", "Georgia", "serif"],
         mono: ["var(--font-mono)", "Menlo", "monospace"],
       },


### PR DESCRIPTION
## Summary
- remove stray `main` token in `tailwind.config.ts` fontFamily configuration

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe1972b78832d9a16e8a2c5367b3e