### PR TITLE
Add blue, pink, yellow themes with gradient buttons and dynamic logos

### DIFF
--- a/src/__tests__/theme-variations.test.ts
+++ b/src/__tests__/theme-variations.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
 
-const themes = ["blue", "pink", "green", "orange", "red"] as const;
+const themes = ["blue", "pink", "yellow"] as const;
 
 describe("theme variations", () => {
   it("defines dark mode overrides for each theme", () => {

--- a/src/assets/Blue.svg
+++ b/src/assets/Blue.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
+  <text x="0" y="20" fill="#2979ff" font-size="20">FINTRAK</text>
+</svg>

--- a/src/assets/Pink.svg
+++ b/src/assets/Pink.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
+  <text x="0" y="20" fill="#ff0086" font-size="20">FINTRAK</text>
+</svg>

--- a/src/assets/Yellow.svg
+++ b/src/assets/Yellow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24">
+  <text x="0" y="20" fill="#ffff00" font-size="20">FINTRAK</text>
+</svg>

--- a/src/components/home-header.tsx
+++ b/src/components/home-header.tsx
@@ -2,7 +2,10 @@ import { Package, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ThemeSelector } from "@/components/theme-selector";
 import { ExportButtons } from "@/components/export-buttons";
-import fintrakLogo from "../assets/fintrak-logo.png";
+import { useTheme } from "@/contexts/simple-theme-context";
+import blueLogo from "../assets/Blue.svg";
+import pinkLogo from "../assets/Pink.svg";
+import yellowLogo from "../assets/Yellow.svg";
 import { formatCurrency } from "@/lib/utils";
 import type { FinancialRow } from "@shared/schema";
 
@@ -45,12 +48,15 @@ export function HomeHeader({
     totalBankBalance,
   };
 
+  const { theme } = useTheme();
+  const logos = { blue: blueLogo, pink: pinkLogo, yellow: yellowLogo };
+
   return (
     <header className="sticky top-0 z-50 bg-background shadow-sm border-b border-border backdrop-blur-sm">
       <div className="max-w-7xl mx-auto px-3 sm:px-4 lg:px-8">
         <div className="flex justify-between items-center h-14 sm:h-16">
           <div className="flex items-center min-w-0">
-            <img src={fintrakLogo} alt="FINTRAK Logo" className="h-7 sm:h-9 object-contain" />
+            <img src={logos[theme]} alt="FINTRAK Logo" className="h-7 sm:h-9 object-contain" />
           </div>
 
           {/* Desktop controls */}

--- a/src/components/theme-selector.css
+++ b/src/components/theme-selector.css
@@ -1,24 +1,15 @@
 .theme-button[data-theme="blue"] {
-  --primary: 211 100% 50%; /* #007AFF */
-  --tw-ring-color: #80bdff;
+  --primary: 218 100% 58%; /* #2979ff */
+  --tw-ring-color: #94bcff;
 }
 
 .theme-button[data-theme="pink"] {
-  --primary: 343 100% 59%; /* #FF2D55 */
-  --tw-ring-color: #ff96aa;
+  --primary: 328 100% 50%; /* #ff0086 */
+  --tw-ring-color: #ff80c3;
 }
 
-.theme-button[data-theme="green"] {
-  --primary: 133 73% 63%; /* #4CD964 */
-  --tw-ring-color: #a6ecb2;
+.theme-button[data-theme="yellow"] {
+  --primary: 60 100% 50%; /* #ffff00 */
+  --tw-ring-color: #ffff80;
 }
 
-.theme-button[data-theme="orange"] {
-  --primary: 35 100% 50%; /* #FF9500 */
-  --tw-ring-color: #ffca80;
-}
-
-.theme-button[data-theme="red"] {
-  --primary: 355 100% 59%; /* #FF3B30 */
-  --tw-ring-color: #ff9d98;
-}

--- a/src/components/theme-selector.tsx
+++ b/src/components/theme-selector.tsx
@@ -19,8 +19,8 @@ export function ThemeSelector() {
             key={id}
             data-theme={id}
             onClick={() => setTheme(id)}
-            className={`theme-button w-10 h-4 rounded-full border-2 shadow-md transition-all bg-primary ${
-              theme === id ? "border-white ring-2" : "border-gray-300"
+            className={`theme-button w-10 h-4 rounded-full border-2 border-primary shadow-md transition-all bg-primary ${
+              theme === id ? "ring-2" : ""
             }`}
             aria-label={`${id.charAt(0).toUpperCase() + id.slice(1)} theme`}
           />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,23 +5,18 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation [-webkit-tap-highlight-color:transparent]",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation [-webkit-tap-highlight-color:transparent] text-[#02081] bg-[linear-gradient(90deg,hsl(var(--primary))_15%,hsl(var(--primary))_60%,hsl(var(--secondary))_100%)]",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-        income:
-          "bg-green-50 hover:bg-green-100 border border-green-200 text-green-700 dark:bg-green-950/50 dark:hover:bg-green-900/50 dark:border-green-800 dark:text-green-300",
-        expense:
-          "bg-red-50 hover:bg-red-100 border border-red-200 text-red-700 dark:bg-red-950/50 dark:hover:bg-red-900/50 dark:border-red-800 dark:text-red-300",
+        default: "hover:opacity-90",
+        destructive: "hover:opacity-90",
+        outline: "border border-primary",
+        secondary: "hover:opacity-90",
+        ghost: "hover:opacity-90",
+        link: "underline-offset-4 hover:underline",
+        income: "hover:opacity-90",
+        expense: "hover:opacity-90",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-sm font-medium leading-none text-primary peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
 const Label = React.forwardRef<

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,11 +1,9 @@
-export type Theme = "blue" | "pink" | "green" | "orange" | "red";
+export type Theme = "blue" | "pink" | "yellow";
 
-export const themeColors: Record<Theme, string> = {
-  blue: "#007AFF",
-  pink: "#FF2D55",
-  green: "#4CD964",
-  orange: "#FF9500",
-  red: "#FF3B30",
+export const themeColors: Record<Theme, { primary: string; secondary: string }> = {
+  blue: { primary: "#2979ff", secondary: "#16ffdb" },
+  pink: { primary: "#ff0086", secondary: "#5c19e5" },
+  yellow: { primary: "#ffff00", secondary: "#06ff00" },
 };
 
 function hexToRgb(hex: string): [number, number, number] {
@@ -27,7 +25,7 @@ function rgbToHex(r: number, g: number, b: number): string {
 }
 
 export function getRingColor(theme: Theme, amount = 0.5): string {
-  const [r, g, b] = hexToRgb(themeColors[theme]);
+  const [r, g, b] = hexToRgb(themeColors[theme].primary);
   const ringR = r + (255 - r) * amount;
   const ringG = g + (255 - g) * amount;
   const ringB = b + (255 - b) * amount;

--- a/src/contexts/simple-theme-context.tsx
+++ b/src/contexts/simple-theme-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { apiRequest } from "@/lib/queryClient";
 
-type Theme = "blue" | "pink" | "green" | "orange" | "red";
+type Theme = "blue" | "pink" | "yellow";
 
 type ThemeProviderState = {
   theme: Theme;

--- a/src/contexts/theme-context.tsx
+++ b/src/contexts/theme-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { apiRequest } from "@/lib/queryClient";
 
-type Theme = "blue" | "pink" | "green" | "orange" | "red";
+type Theme = "blue" | "pink" | "yellow";
 
 type ThemeProviderState = {
   theme: Theme;

--- a/src/index.css
+++ b/src/index.css
@@ -72,56 +72,40 @@
 
 /* Theme color variations - iOS color palette */
 body[data-theme="blue"] {
-  --primary: 211 100% 50%; /* #007AFF */
+  --primary: 218 100% 58%; /* #2979ff */
+  --secondary: 171 100% 54%; /* #16ffdb */
   --primary-foreground: 0 0% 100%;
 }
 
 body[data-theme="pink"] {
-  --primary: 343 100% 59%; /* #FF2D55 */
+  --primary: 328 100% 50%; /* #ff0086 */
+  --secondary: 260 80% 50%; /* #5c19e5 */
   --primary-foreground: 0 0% 100%;
 }
 
-body[data-theme="green"] {
-  --primary: 133 73% 63%; /* #4CD964 */
-  --primary-foreground: 0 0% 0%; /* for hsl() */
-}
-
-body[data-theme="orange"] {
-  --primary: 35 100% 50%; /* #FF9500 */
+body[data-theme="yellow"] {
+  --primary: 60 100% 50%; /* #ffff00 */
+  --secondary: 119 100% 50%; /* #06ff00 */
   --primary-foreground: 0 0% 0%;
-}
-
-body[data-theme="red"] {
-  --primary: 355 100% 59%; /* #FF3B30 */
-  --primary-foreground: 0 0% 100%;
 }
 body.dark[data-theme="blue"],
 .dark body[data-theme="blue"] {
-  --primary: 217 91% 60%;
+  --primary: 218 100% 58%;
+  --secondary: 171 100% 54%;
   --primary-foreground: 222.2 84% 4.9%;
 }
 
 body.dark[data-theme="pink"],
 .dark body[data-theme="pink"] {
-  --primary: 343 100% 59%;
+  --primary: 328 100% 50%;
+  --secondary: 260 80% 50%;
   --primary-foreground: 222.2 84% 4.9%;
 }
 
-body.dark[data-theme="green"],
-.dark body[data-theme="green"] {
-  --primary: 133 73% 63%;
-  --primary-foreground: 222.2 84% 4.9%;
-}
-
-body.dark[data-theme="orange"],
-.dark body[data-theme="orange"] {
-  --primary: 35 100% 50%;
-  --primary-foreground: 222.2 84% 4.9%;
-}
-
-body.dark[data-theme="red"],
-.dark body[data-theme="red"] {
-  --primary: 355 100% 59%;
+body.dark[data-theme="yellow"],
+.dark body[data-theme="yellow"] {
+  --primary: 60 100% 50%;
+  --secondary: 119 100% 50%;
   --primary-foreground: 222.2 84% 4.9%;
 }
 

--- a/src/pages/inventory-page.tsx
+++ b/src/pages/inventory-page.tsx
@@ -6,7 +6,10 @@ import { InventoryTracker } from "@/components/inventory-tracker";
 import { SalesTracker } from "@/components/sales-tracker";
 import { useLocation } from "wouter";
 import type { InventoryBatch } from "@shared/schema";
-import fintrakLogo from "../assets/fintrak-logo.png";
+import { useTheme } from "@/contexts/simple-theme-context";
+import blueLogo from "../assets/Blue.svg";
+import pinkLogo from "../assets/Pink.svg";
+import yellowLogo from "../assets/Yellow.svg";
 
 export default function InventoryPage() {
   const [, setLocation] = useLocation();
@@ -15,6 +18,9 @@ export default function InventoryPage() {
   const handleBatchSelect = (batch: InventoryBatch) => {
     setSelectedBatch(batch);
   };
+
+  const { theme } = useTheme();
+  const logos = { blue: blueLogo, pink: pinkLogo, yellow: yellowLogo };
 
   return (
     <div className="min-h-screen bg-background">
@@ -31,10 +37,10 @@ export default function InventoryPage() {
                 <ArrowLeft className="h-4 w-4 mr-1" />
                 Back to Financial Calculator
               </Button>
-              
+
               <div className="flex items-center gap-2">
                 <img
-                  src={fintrakLogo}
+                  src={logos[theme]}
                   alt="FINTRAK"
                   className="h-8 w-auto object-contain"
                 />

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -8,7 +8,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Eye, EyeOff, LogIn, Calculator } from "lucide-react";
 import { apiRequest, queryClient } from "@/lib/queryClient";
-import fintrakLogo from "../assets/fintrak-logo.png";
+import { useTheme } from "@/contexts/simple-theme-context";
+import blueLogo from "../assets/Blue.svg";
+import pinkLogo from "../assets/Pink.svg";
+import yellowLogo from "../assets/Yellow.svg";
 
 export default function LoginPage() {
   const [, setLocation] = useLocation();
@@ -43,6 +46,9 @@ export default function LoginPage() {
     loginMutation.mutate({ username, password });
   };
 
+  const { theme } = useTheme();
+  const logos = { blue: blueLogo, pink: pinkLogo, yellow: yellowLogo };
+
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <div className="w-full max-w-md">
@@ -50,7 +56,7 @@ export default function LoginPage() {
           <CardHeader className="text-center pb-4">
             <div className="flex justify-center mb-4">
               <img
-                src={fintrakLogo}
+                src={logos[theme]}
                 alt="FINTRAK"
                 className="h-12 w-auto object-contain"
               />


### PR DESCRIPTION
## Summary
- replace prior color set with blue, pink, and yellow themes including primary and secondary hues
- apply theme colors to CSS variables, borders, and gradient buttons with new default label color
- switch logos based on selected theme and add themed SVG assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abec8e768c832d8c95a8b606700ee7