### PR TITLE
refactor: remove duplicate logo imports

### DIFF
--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -12,12 +12,6 @@ import { useTheme } from "@/contexts/simple-theme-context";
 import blueLogo from "@/assets/Blue.svg";
 import pinkLogo from "@/assets/Pink.svg";
 import yellowLogo from "@/assets/Yellow.svg";
-import blueLogo from "@/assets/Blue.svg";
-import pinkLogo from "@/assets/Pink.svg";
-import yellowLogo from "@/assets/Yellow.svg";
-import blueLogo from "../assets/Blue.svg";
-import pinkLogo from "../assets/Pink.svg";
-import yellowLogo from "../assets/Yellow.svg";
 
 
 export default function LoginPage() {


### PR DESCRIPTION
## Summary
- remove duplicate Blue, Pink, and Yellow logo imports in login page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0b4f06fc832db35db73541e5a95e