### PR TITLE
feat: add inventory batch deletion

### DIFF
--- a/netlify/functions/inventory-batches.js
+++ b/netlify/functions/inventory-batches.js
@@ -100,6 +100,35 @@ exports.handler = async (event, context) => {
       };
     }
 
+    if (httpMethod === 'DELETE') {
+      const pathParts = event.path.split('/');
+      const batchId = pathParts[pathParts.length - 1];
+
+      const { data, error } = await supabase
+        .from('inventory_batches')
+        .delete()
+        .eq('id', batchId)
+        .eq('user_id', userId)
+        .select()
+        .single();
+
+      if (error && error.code === 'PGRST116') {
+        return {
+          statusCode: 404,
+          headers,
+          body: JSON.stringify({ error: 'Batch not found' })
+        };
+      }
+
+      if (error) throw error;
+
+      return {
+        statusCode: 204,
+        headers,
+        body: ''
+      };
+    }
+
     return {
       statusCode: 405,
       headers,

--- a/src/components/inventory-tracker.tsx
+++ b/src/components/inventory-tracker.tsx
@@ -102,12 +102,19 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
   const deleteBatchMutation = useMutation({
     mutationFn: async (batchId: string) => {
       try {
-        await apiRequest("DELETE", `/api/inventory-batches/${batchId}`);
-      } catch (error) {
-        // Offline mode - remove from localStorage
-        const localData = JSON.parse(localStorage.getItem('fintrak-inventory-batches') || '[]');
-        const filtered = localData.filter((b: any) => b.id !== batchId);
-        localStorage.setItem('fintrak-inventory-batches', JSON.stringify(filtered));
+        const res = await apiRequest("DELETE", `/api/inventory-batches/${batchId}`);
+        if (res.status !== 204) {
+          throw new Error(`Unexpected response: ${res.status}`);
+        }
+      } catch (error: any) {
+        if (error instanceof TypeError || error.message.includes('Failed to fetch')) {
+          // Offline mode - remove from localStorage
+          const localData = JSON.parse(localStorage.getItem('fintrak-inventory-batches') || '[]');
+          const filtered = localData.filter((b: any) => b.id !== batchId);
+          localStorage.setItem('fintrak-inventory-batches', JSON.stringify(filtered));
+        } else {
+          throw error;
+        }
       }
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- add DELETE handler in inventory-batches function with ownership validation and proper status codes
- handle 204 response for batch deletion in inventory tracker, with offline fallback only on network errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0bbd7c38832db4740e1c2e27f392