### PR TITLE
Unify inventory schema with pricing columns

### DIFF
--- a/netlify/functions/inventory-batches.js
+++ b/netlify/functions/inventory-batches.js
@@ -30,10 +30,26 @@ exports.handler = async (event, context) => {
 
       if (error) throw error;
 
+      const camelData = (data || []).map((row) => ({
+        id: row.id,
+        userId: row.user_id,
+        batchName: row.batch_name,
+        productName: row.product_name,
+        totalPricePaid: row.total_price_paid,
+        numberOfUnits: row.number_of_units,
+        unitCost: row.unit_cost,
+        projectedSaleCostPerUnit: row.projected_sale_cost_per_unit,
+        actualSaleCostPerUnit: row.actual_sale_cost_per_unit,
+        qtyInStock: row.qty_in_stock,
+        qtySold: row.qty_sold,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      }));
+
       return {
         statusCode: 200,
         headers,
-        body: JSON.stringify(data || [])
+        body: JSON.stringify(camelData)
       };
     }
 
@@ -45,11 +61,13 @@ exports.handler = async (event, context) => {
         user_id: userId,
         batch_name: requestData.batchName,
         product_name: requestData.productName,
+        total_price_paid: requestData.totalPricePaid || '0',
+        number_of_units: requestData.numberOfUnits || 0,
+        unit_cost: requestData.unitCost || '0',
+        projected_sale_cost_per_unit: requestData.projectedSaleCostPerUnit || '0',
+        actual_sale_cost_per_unit: requestData.actualSaleCostPerUnit || '0',
         qty_in_stock: requestData.qtyInStock || 0,
         qty_sold: requestData.qtySold || 0,
-        cost_per_unit: requestData.unitCost || '0',
-        projected_sale_cost_per_unit: requestData.projectedSaleCostPerUnit || '0',
-        actual_sale_cost_per_unit: requestData.actualSaleCostPerUnit || '0'
       };
       
       const { data, error } = await supabase
@@ -60,10 +78,26 @@ exports.handler = async (event, context) => {
 
       if (error) throw error;
 
+      const camelData = {
+        id: data.id,
+        userId: data.user_id,
+        batchName: data.batch_name,
+        productName: data.product_name,
+        totalPricePaid: data.total_price_paid,
+        numberOfUnits: data.number_of_units,
+        unitCost: data.unit_cost,
+        projectedSaleCostPerUnit: data.projected_sale_cost_per_unit,
+        actualSaleCostPerUnit: data.actual_sale_cost_per_unit,
+        qtyInStock: data.qty_in_stock,
+        qtySold: data.qty_sold,
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+      };
+
       return {
         statusCode: 201,
         headers,
-        body: JSON.stringify(data)
+        body: JSON.stringify(camelData)
       };
     }
 
@@ -76,11 +110,13 @@ exports.handler = async (event, context) => {
       const dbData = {
         batch_name: requestData.batchName,
         product_name: requestData.productName,
+        total_price_paid: requestData.totalPricePaid || '0',
+        number_of_units: requestData.numberOfUnits || 0,
+        unit_cost: requestData.unitCost || '0',
+        projected_sale_cost_per_unit: requestData.projectedSaleCostPerUnit || '0',
+        actual_sale_cost_per_unit: requestData.actualSaleCostPerUnit || '0',
         qty_in_stock: requestData.qtyInStock || 0,
         qty_sold: requestData.qtySold || 0,
-        cost_per_unit: requestData.unitCost || '0',
-        projected_sale_cost_per_unit: requestData.projectedSaleCostPerUnit || '0',
-        actual_sale_cost_per_unit: requestData.actualSaleCostPerUnit || '0'
       };
       
       const { data, error } = await supabase
@@ -93,10 +129,26 @@ exports.handler = async (event, context) => {
 
       if (error) throw error;
 
+      const camelData = {
+        id: data.id,
+        userId: data.user_id,
+        batchName: data.batch_name,
+        productName: data.product_name,
+        totalPricePaid: data.total_price_paid,
+        numberOfUnits: data.number_of_units,
+        unitCost: data.unit_cost,
+        projectedSaleCostPerUnit: data.projected_sale_cost_per_unit,
+        actualSaleCostPerUnit: data.actual_sale_cost_per_unit,
+        qtyInStock: data.qty_in_stock,
+        qtySold: data.qty_sold,
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+      };
+
       return {
         statusCode: 200,
         headers,
-        body: JSON.stringify(data)
+        body: JSON.stringify(camelData)
       };
     }
 

--- a/netlify/functions/sales-records.js
+++ b/netlify/functions/sales-records.js
@@ -22,18 +22,37 @@ exports.handler = async (event, context) => {
     const userId = "46429020";
 
     if (httpMethod === 'GET') {
-      const { data, error } = await supabase
+      const batchId = event.queryStringParameters ? event.queryStringParameters.batchId : undefined;
+      let query = supabase
         .from('sales_records')
         .select('*')
         .eq('user_id', userId)
         .order('created_at', { ascending: false });
+      if (batchId) {
+        query = query.eq('batch_id', batchId);
+      }
+      const { data, error } = await query;
 
       if (error) throw error;
+
+      const camelData = (data || []).map((row) => ({
+        id: row.id,
+        userId: row.user_id,
+        batchId: row.batch_id,
+        qty: row.qty,
+        pricePerUnit: row.price_per_unit,
+        totalPrice: row.total_price,
+        amountPaid: row.amount_paid,
+        balanceOwing: row.balance_owing,
+        notes: row.notes,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      }));
 
       return {
         statusCode: 200,
         headers,
-        body: JSON.stringify(data || [])
+        body: JSON.stringify(camelData)
       };
     }
 
@@ -48,7 +67,8 @@ exports.handler = async (event, context) => {
         price_per_unit: requestData.pricePerUnit || requestData.price_per_unit,
         total_price: requestData.totalPrice || requestData.total_price,
         amount_paid: requestData.amountPaid || requestData.amount_paid,
-        notes: requestData.notes || ''
+        balance_owing: requestData.balanceOwing || requestData.balance_owing || '0',
+        notes: requestData.notes || '',
       };
       
       const { data, error } = await supabase
@@ -59,10 +79,24 @@ exports.handler = async (event, context) => {
 
       if (error) throw error;
 
+      const camelData = {
+        id: data.id,
+        userId: data.user_id,
+        batchId: data.batch_id,
+        qty: data.qty,
+        pricePerUnit: data.price_per_unit,
+        totalPrice: data.total_price,
+        amountPaid: data.amount_paid,
+        balanceOwing: data.balance_owing,
+        notes: data.notes,
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+      };
+
       return {
         statusCode: 201,
         headers,
-        body: JSON.stringify(data)
+        body: JSON.stringify(camelData)
       };
     }
 

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -33,11 +33,13 @@ CREATE TABLE IF NOT EXISTS inventory_batches (
   user_id TEXT NOT NULL,
   batch_name TEXT NOT NULL,
   product_name TEXT NOT NULL,
-  qty_in_stock INTEGER NOT NULL DEFAULT 0,
-  qty_sold INTEGER NOT NULL DEFAULT 0,
-  cost_per_unit TEXT NOT NULL,
+  total_price_paid TEXT NOT NULL,
+  number_of_units INTEGER NOT NULL,
+  unit_cost TEXT NOT NULL,
   projected_sale_cost_per_unit TEXT DEFAULT '0',
   actual_sale_cost_per_unit TEXT DEFAULT '0',
+  qty_in_stock INTEGER NOT NULL DEFAULT 0,
+  qty_sold INTEGER NOT NULL DEFAULT 0,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -51,10 +53,46 @@ CREATE TABLE IF NOT EXISTS sales_records (
   price_per_unit TEXT NOT NULL,
   total_price TEXT NOT NULL,
   amount_paid TEXT NOT NULL,
+  balance_owing TEXT NOT NULL,
   notes TEXT DEFAULT '',
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+-- Migrate existing inventory_batches data to the new schema
+ALTER TABLE inventory_batches
+  ADD COLUMN IF NOT EXISTS total_price_paid TEXT DEFAULT '0',
+  ADD COLUMN IF NOT EXISTS number_of_units INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS unit_cost TEXT DEFAULT '0';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='inventory_batches' AND column_name='cost_per_unit'
+  ) THEN
+    UPDATE inventory_batches
+    SET
+      unit_cost = COALESCE(unit_cost, cost_per_unit, '0'),
+      number_of_units = CASE
+        WHEN number_of_units = 0 THEN COALESCE(qty_in_stock,0) + COALESCE(qty_sold,0)
+        ELSE number_of_units
+      END,
+      total_price_paid = CASE
+        WHEN total_price_paid = '0' THEN ((COALESCE(qty_in_stock,0) + COALESCE(qty_sold,0)) * COALESCE(cost_per_unit, '0')::numeric)::text
+        ELSE total_price_paid
+      END;
+    ALTER TABLE inventory_batches DROP COLUMN IF EXISTS cost_per_unit;
+  END IF;
+END $$;
+
+-- Migrate existing sales_records data to include balance_owing
+ALTER TABLE sales_records
+  ADD COLUMN IF NOT EXISTS balance_owing TEXT DEFAULT '0';
+
+UPDATE sales_records
+SET balance_owing = (COALESCE(total_price, '0')::numeric - COALESCE(amount_paid, '0')::numeric)::text
+WHERE balance_owing = '0';
 
 -- Create indexes for better performance
 CREATE INDEX IF NOT EXISTS idx_financial_data_user_id ON financial_data(user_id);


### PR DESCRIPTION
## Summary
- add `total_price_paid`, `number_of_units`, and `unit_cost` to `inventory_batches` and migrate old data
- store `balance_owing` in `sales_records`
- update Netlify functions to map new fields and return camelCase payloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0bbcf1cc832dad7c91a07f94f97e