### PR TITLE
feat: improve theme selector accessibility

### DIFF
--- a/src/components/theme-selector.tsx
+++ b/src/components/theme-selector.tsx
@@ -12,14 +12,14 @@ export function ThemeSelector() {
 
   return (
     <div className="flex items-center space-x-2 sm:space-x-3">
-      {/* Theme Color Buttons - Hidden on mobile */}
-      <div className="hidden md:flex items-center space-x-2">
+      {/* Theme Color Buttons - Visible on mobile */}
+      <div className="flex items-center space-x-2">
         {themeOptions.map((id) => (
           <button
             key={id}
             data-theme={id}
             onClick={() => setTheme(id)}
-            className={`theme-button w-10 h-4 rounded-full border-2 border-primary shadow-md transition-all bg-primary ${
+            className={`theme-button w-11 h-11 rounded-full border-2 border-primary shadow-md transition-all bg-primary focus-visible:ring-2 focus-visible:ring-offset-2 ${
               theme === id ? "ring-2" : ""
             }`}
             aria-label={`${id.charAt(0).toUpperCase() + id.slice(1)} theme`}


### PR DESCRIPTION
## Summary
- enlarge theme buttons for easier interaction and visibility on mobile
- add focus-visible ring and offset for keyboard accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0cb9c474832db54ceeb205f38a48