### PR TITLE
chore: centralize input styling in Input component

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -58,13 +58,7 @@
   }
 }
 
-/* Override input styling for dark theme */
 @layer components {
-  .dark-input {
-    @apply bg-input text-foreground border-primary border-opacity-70;
-    border-width: 0.5px;
-  }
-
   .text-muted {
     @apply text-muted-foreground;
   }


### PR DESCRIPTION
## Summary
- remove unused `.dark-input` CSS since the Input component handles dark theme styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac0cbe5dc4832d8d7e8b37465ef2aa