### PR TITLE
feat: make cash calculator inputs responsive

### DIFF
--- a/src/components/cash-calculator.tsx
+++ b/src/components/cash-calculator.tsx
@@ -84,7 +84,7 @@ export function CashCalculator({ denominations, onUpdate }: CashCalculatorProps)
                     inputMode="numeric"
                     value={quantity || ""}
                     onChange={(e) => updateDenomination(note.key, parseInt(e.target.value) || 0)}
-                    className="w-16 text-right text-base bg-input text-foreground border-border"
+                    className="min-w-[4rem] flex-1 text-right text-base bg-input text-foreground border-border"
                     min="0"
                     placeholder="0"
                   />
@@ -129,7 +129,7 @@ export function CashCalculator({ denominations, onUpdate }: CashCalculatorProps)
                     inputMode="numeric"
                     value={quantity || ""}
                     onChange={(e) => updateDenomination(coin.key, parseInt(e.target.value) || 0)}
-                    className="w-16 text-right text-base bg-input text-foreground border-border"
+                    className="min-w-[4rem] flex-1 text-right text-base bg-input text-foreground border-border"
                     min="0"
                     placeholder="0"
                   />


### PR DESCRIPTION
## Summary
- tweak cash calculator inputs to use `min-w-[4rem] flex-1` so big numbers stay visible and text stays right-aligned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0cc38634832d96fa050afc29a9c1