### PR TITLE
Use neutral border tokens for inputs

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border-[0.5px] border-primary border-opacity-70 bg-input px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 md:text-sm touch-manipulation [-webkit-tap-highlight-color:transparent]",
+          "flex h-10 w-full rounded-md border-[0.5px] border-border bg-input px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-1 focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 md:text-sm touch-manipulation [-webkit-tap-highlight-color:transparent]",
           className
         )}
         ref={ref}

--- a/src/index.css
+++ b/src/index.css
@@ -22,7 +22,7 @@
   --input: 222.86 84% 4.9%;
   /* Match border and ring colors to the current theme */
   --ring: var(--primary);
-  --border: var(--primary);
+  --border: 215 20% 25%;
   --card-border: var(--primary);
   --radius: 0.75rem;
 }
@@ -61,7 +61,7 @@
 /* Override input styling for dark theme */
 @layer components {
   .dark-input {
-    @apply bg-input text-foreground border-primary border-opacity-70;
+    @apply bg-input text-foreground border-border;
     border-width: 0.5px;
   }
 
@@ -75,7 +75,7 @@ body[data-theme="blue"] {
   --primary: 218 100% 58%; /* #2979ff */
   --secondary: 171 100% 54%; /* #16ffdb */
   --primary-foreground: 0 0% 100%;
-  --border: var(--primary);
+  --border: 215 20% 25%;
   --ring: var(--primary);
 }
 
@@ -83,7 +83,7 @@ body[data-theme="pink"] {
   --primary: 328 100% 50%; /* #ff0086 */
   --secondary: 260 80% 50%; /* #5c19e5 */
   --primary-foreground: 0 0% 100%;
-  --border: var(--primary);
+  --border: 215 20% 25%;
   --ring: var(--primary);
 }
 
@@ -91,7 +91,7 @@ body[data-theme="yellow"] {
   --primary: 60 100% 50%; /* #ffff00 */
   --secondary: 119 100% 50%; /* #06ff00 */
   --primary-foreground: 0 0% 0%;
-  --border: var(--primary);
+  --border: 215 20% 25%;
   --ring: var(--primary);
 }
 
@@ -100,7 +100,7 @@ body.dark[data-theme="blue"],
   --primary: 218 100% 58%;
   --secondary: 171 100% 54%;
   --primary-foreground: 222.2 84% 4.9%;
-  --border: var(--primary);
+  --border: 215 20% 25%;
   --ring: var(--primary);
 }
 
@@ -109,7 +109,7 @@ body.dark[data-theme="pink"],
   --primary: 328 100% 50%;
   --secondary: 260 80% 50%;
   --primary-foreground: 222.2 84% 4.9%;
-  --border: var(--primary);
+  --border: 215 20% 25%;
   --ring: var(--primary);
 }
 
@@ -118,7 +118,7 @@ body.dark[data-theme="yellow"],
   --primary: 60 100% 50%;
   --secondary: 119 100% 50%;
   --primary-foreground: 222.2 84% 4.9%;
-  --border: var(--primary);
+  --border: 215 20% 25%;
   --ring: var(--primary);
 }
 


### PR DESCRIPTION
## Summary
- use `border-border` utility in input component for subdued default border
- set `--border` theme variable to neutral HSL across themes so focus rings remain primary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac0ccbea94832db2506f6a3854180b