### PR TITLE
fix: improve button styling

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,9 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-const BUTTON_TEXT_COLOR = "#02081"
+// Dark blue used throughout the app as the background color
+// used here to ensure button text matches the design palette
+const BUTTON_TEXT_COLOR = "#020817"
 
 const buttonVariants = cva(
 
@@ -13,7 +15,7 @@ const buttonVariants = cva(
 
   `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation [-webkit-tap-highlight-color:transparent] text-[${BUTTON_TEXT_COLOR}] bg-[linear-gradient(-50deg,hsl(var(--primary))_15%,hsl(var(--primary))_60%,hsl(var(--secondary))_100%)]`,
 
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation [-webkit-tap-highlight-color:transparent] text-[#02081] bg-[linear-gradient(90deg,hsl(var(--primary))_15%,hsl(var(--primary))_60%,hsl(var(--secondary))_100%)]",
+    `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 touch-manipulation [-webkit-tap-highlight-color:transparent] text-[${BUTTON_TEXT_COLOR}] bg-[linear-gradient(90deg,hsl(var(--primary))_15%,hsl(var(--primary))_60%,hsl(var(--secondary))_100%)]`,
 
 
   {
@@ -29,10 +31,11 @@ const buttonVariants = cva(
         expense: "hover:opacity-90",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        // Increase padding and remove fixed heights so buttons feel less squashed
+        default: "px-6 py-4",
+        sm: "rounded-md px-4 py-2",
+        lg: "rounded-md px-10 py-6",
+        icon: "h-12 w-12",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- increase button padding to prevent squashed appearance
- ensure button text uses dark blue background color

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1299f298832daf4a0984792fd678