### PR TITLE
refactor: remove duplicate logo imports

### DIFF
--- a/src/components/home-header.tsx
+++ b/src/components/home-header.tsx
@@ -6,12 +6,6 @@ import { useTheme } from "@/contexts/simple-theme-context";
 import blueLogo from "@/assets/Blue.svg";
 import pinkLogo from "@/assets/Pink.svg";
 import yellowLogo from "@/assets/Yellow.svg";
-import blueLogo from "@/assets/Blue.svg";
-import pinkLogo from "@/assets/Pink.svg";
-import yellowLogo from "@/assets/Yellow.svg";
-import blueLogo from "../assets/Blue.svg";
-import pinkLogo from "../assets/Pink.svg";
-import yellowLogo from "../assets/Yellow.svg";
 import { formatCurrency } from "@/lib/utils";
 import type { FinancialRow } from "@shared/schema";
 

--- a/src/pages/inventory-page.tsx
+++ b/src/pages/inventory-page.tsx
@@ -10,12 +10,6 @@ import { useTheme } from "@/contexts/simple-theme-context";
 import blueLogo from "@/assets/Blue.svg";
 import pinkLogo from "@/assets/Pink.svg";
 import yellowLogo from "@/assets/Yellow.svg";
-import blueLogo from "@/assets/Blue.svg";
-import pinkLogo from "@/assets/Pink.svg";
-import yellowLogo from "@/assets/Yellow.svg";
-import blueLogo from "../assets/Blue.svg";
-import pinkLogo from "../assets/Pink.svg";
-import yellowLogo from "../assets/Yellow.svg";
 
 
 export default function InventoryPage() {


### PR DESCRIPTION
## Summary
- remove redundant logo imports from home header
- dedupe logo imports in inventory page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac12b52ffc832db6ba123aee5e6df0