### PR TITLE
Fallback to local storage on failed inventory fetch

### DIFF
--- a/src/components/inventory-tracker.tsx
+++ b/src/components/inventory-tracker.tsx
@@ -41,11 +41,16 @@ export function InventoryTracker({ onBatchSelect, selectedBatchId }: InventoryTr
           credentials: "include",
         });
         if (response.status === 401) {
+          console.log("Loading inventory from localStorage");
           // Load from localStorage when server unavailable
           const localData = localStorage.getItem('fintrak-inventory-batches');
           return localData ? JSON.parse(localData) : [];
         }
-        if (!response.ok) return [];
+        if (!response.ok) {
+          console.log("Loading inventory from localStorage");
+          const localData = localStorage.getItem('fintrak-inventory-batches');
+          return localData ? JSON.parse(localData) : [];
+        }
         const data = await response.json();
         // Save to localStorage as backup
         localStorage.setItem('fintrak-inventory-batches', JSON.stringify(data));


### PR DESCRIPTION
## Summary
- Load and parse `fintrak-inventory-batches` from localStorage whenever the `/api/inventory-batches` request is not ok
- Preserve error logging for all fallback paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac12c5d34c832d95369b9d3bf488fe